### PR TITLE
MD links

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-router-dom": "^6.26.1",
     "react-select": "^5.8.0",
     "react-swipeable": "^7.0.1",
+    "rehype-raw": "6",
     "use-debounce": "^10.0.4",
     "uuid": "^11.1.0"
   },

--- a/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
+++ b/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
@@ -109,39 +109,36 @@ const RetailerCardModal = ({
                                 style={{ width: '100%' }}
                             >
                                 {terms ? (
-                                    <Markdown 
-                                        className={`${styles.markdown} ${styles.markdown_short}`}
-                                        rehypePlugins={[rehypeRaw]}
-                                        components={{
-                                            a: ({ href, children, ...props }) => {
-                                                if (href?.startsWith('#')) {
-                                                    return <a href={href} {...props}>{children}</a>
-                                                }
-                                                if (href?.startsWith('http')) {
-                                                    const url = new URL(href)
-                                                    url.searchParams.set('platform', platform.toUpperCase())
-                                                    url.searchParams.set('address', walletAddress || 'null')
-                                                    url.searchParams.set('env', ENV)                                                    
-                                                    return (
-                                                        <a
-                                                            {...props}
-                                                            className={styles.externalLink}
-                                                            href="#"
-                                                            onClick={(e) => {
-                                                                e.preventDefault()
-                                                                window.open(url.toString(), '_blank', 'noopener,noreferrer')
-                                                            }}
-                                                        >
-                                                            {children}
-                                                        </a>
-                                                    )
-                                                }
-                                                return <a href={href} {...props}>{children}</a>
-                                            }
-                                        }}
-                                    >
-                                        {terms}
-                                    </Markdown>
+                            <Markdown 
+                                className={styles.markdown}
+                                rehypePlugins={[rehypeRaw]}
+                                components={{
+                                    a: ({ href, children, ...props }) => {
+                                        if (href?.startsWith('#')) {
+                                            return <a href={href} {...props}>{children}</a>
+                                        }
+                                        if (href?.startsWith('http')) {
+                                            const url = new URL(href)
+                                            url.searchParams.set('platform', platform.toUpperCase())
+                                            url.searchParams.set('address', walletAddress || 'null')                                    
+                                            url.searchParams.set('env', ENV)                                    
+                                            return (
+                                                <a
+                                                    {...props}                                            
+                                                    href={url.toString()}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                >
+                                                    {children}
+                                                </a>
+                                            )
+                                        }
+                                        return <a href={href} {...props}>{children}</a>
+                                    }
+                                }}
+                            >
+                                {terms}
+                            </Markdown>
                                 ) : (
                                     <div className={`${styles.markdown} ${styles.center}`}>
                                         Loading...

--- a/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
+++ b/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
@@ -256,19 +256,14 @@ const RetailerCardModal = ({
                                 if (href?.startsWith('http')) {
                                     const url = new URL(href)
                                     url.searchParams.set('platform', platform.toUpperCase())
-                                    url.searchParams.set('address', walletAddress || 'null')
-                                    if (ENV !== 'prod') {
-                                        url.searchParams.set('env', ENV)
-                                    }
+                                    url.searchParams.set('address', walletAddress || 'null')                                    
+                                    url.searchParams.set('env', ENV)                                    
                                     return (
                                         <a
-                                            {...props}
-                                            className={styles.externalLink}
-                                            href="#"
-                                            onClick={(e) => {
-                                                e.preventDefault()
-                                                window.open(url.toString(), '_blank', 'noopener,noreferrer')
-                                            }}
+                                            {...props}                                            
+                                            href={url.toString()}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
                                         >
                                             {children}
                                         </a>

--- a/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
+++ b/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
@@ -117,7 +117,7 @@ const RetailerCardModal = ({
                                         if (href?.startsWith('#')) {
                                             return <a href={href} {...props}>{children}</a>
                                         }
-                                        if (href?.startsWith('http')) {
+                                        if (href?.startsWith('http://') || href?.startsWith('https://')) {
                                             const url = new URL(href)
                                             url.searchParams.set('platform', platform.toUpperCase())
                                             url.searchParams.set('address', walletAddress || 'null')                                    
@@ -250,7 +250,7 @@ const RetailerCardModal = ({
                                 if (href?.startsWith('#')) {
                                     return <a href={href} {...props}>{children}</a>
                                 }
-                                if (href?.startsWith('http')) {
+                                if (href?.startsWith('http://') || href?.startsWith('https://')) {
                                     const url = new URL(href)
                                     url.searchParams.set('platform', platform.toUpperCase())
                                     url.searchParams.set('address', walletAddress || 'null')                                    

--- a/src/components/Modals/RetailerCardModal/styles.module.css
+++ b/src/components/Modals/RetailerCardModal/styles.module.css
@@ -92,6 +92,14 @@
     margin-top: 2px;
 }
 
+.markdown a {
+    color: var(--primary-btn-hover-bg);
+    text-decoration: var(--modal-deal-markdown-link-decoration, underline);
+    font-weight: var(--modal-deal-markdown-link-f-w, 400);
+    transition: .2s;
+    cursor: pointer;
+}
+
 .center {
     display: flex;
     justify-content: center;

--- a/src/components/Modals/RetailerCardModal/styles.module.css
+++ b/src/components/Modals/RetailerCardModal/styles.module.css
@@ -93,7 +93,7 @@
 }
 
 .markdown a {
-    color: var(--primary-btn-hover-bg);
+    color: var(--primary-btn-bg);
     text-decoration: var(--modal-deal-markdown-link-decoration, underline);
     font-weight: var(--modal-deal-markdown-link-f-w, 400);
     transition: .2s;


### PR DESCRIPTION
This pull request enhances the `RetailerCardModal` component by improving how Markdown content is rendered and how external links are handled. The changes add support for raw HTML in Markdown, dynamically append query parameters to external links, and update styling for Markdown links.

**Markdown rendering and link handling improvements:**

* Added the `rehype-raw` package and integrated it with the `react-markdown` component to allow rendering of raw HTML within Markdown content. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R31) [[2]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dR4-R13) [[3]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dL108-R139) [[4]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dL214-R272)
* Customized the rendering of anchor (`<a>`) tags in Markdown so that:
  * Internal links (starting with `#`) are left unchanged.
  * External links (starting with `http`) are opened in a new tab and have `platform`, `address`, and `env` query parameters appended dynamically based on the current user and environment. [[1]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dL108-R139) [[2]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dL214-R272)
  * All other links are rendered as standard anchor tags. [[1]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dL108-R139) [[2]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dL214-R272)

**Styling updates:**

* Added CSS rules to style Markdown links within the modal, including color, underline, font weight, and hover effects.

**Component integration:**

* Imported and used new hooks and configuration values (`useWalletAddress`, `ENV`, and `platform`) to supply data for dynamic link generation. [[1]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dR4-R13) [[2]](diffhunk://#diff-3eb62e11674628f3cecdf9c009269e713db09bd2593088315f976abb8c14872dL39-R43)