### PR TITLE
fix: increase width of cashback rate display for better visibility

### DIFF
--- a/src/components/RetailerCard/styles.module.css
+++ b/src/components/RetailerCard/styles.module.css
@@ -95,7 +95,7 @@
     color: var(--retailer-card-amount-f-c);
     background: var(--retailer-card-amount-bg);
     padding: 6px;
-    width: 140px;
+    width: 160px;
     border-radius: 50px;
     text-align: center;
     white-space: nowrap;


### PR DESCRIPTION
PORTAL: The content extends beyond the button. #339
