### PR TITLE
chore: remove unused iconsPath destructured variables

### DIFF
--- a/src/components/Modals/CampaignEndModal/CampaignEndModal.tsx
+++ b/src/components/Modals/CampaignEndModal/CampaignEndModal.tsx
@@ -8,7 +8,7 @@ import formatCashback from '../../../utils/formatCashback'
 import Icon from '../../Icon/Icon'
 
 const CampaignEndModal = ({ open, closeFn }: Omit<ComponentProps<typeof Modal>, 'children'>) => {
-    const { iconsPath, platform } = useRouteLoaderData('root') as LoaderData
+    const { platform } = useRouteLoaderData('root') as LoaderData
     const [params] = useSearchParams()
     const { t } = useTranslation()
     const campaignKey = parseCampaignId(params.get('campaignId'))

--- a/src/components/Modals/LoginModal/LoginModal.tsx
+++ b/src/components/Modals/LoginModal/LoginModal.tsx
@@ -3,7 +3,6 @@ import Modal from '../../Modal/Modal'
 import { ComponentProps } from 'react'
 import message from '../../../utils/message'
 import { useTranslation } from 'react-i18next'
-import { useRouteLoaderData } from 'react-router-dom'
 import Icon from '../../Icon/Icon'
 
 interface Props extends Omit<ComponentProps<typeof Modal>, 'children'> {

--- a/src/components/Modals/LoginModal/LoginModal.tsx
+++ b/src/components/Modals/LoginModal/LoginModal.tsx
@@ -16,7 +16,6 @@ const LoginModal = ({
 }: Props) => {
 
     const { t } = useTranslation()
-    const { iconsPath } = useRouteLoaderData('root') as LoaderData
 
     const onClose = () => {
         message({ action: 'POPUP_CLOSED' })

--- a/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
+++ b/src/components/Modals/RetailerCardModal/RetailerCardModal.tsx
@@ -40,7 +40,7 @@ const RetailerCardModal = ({
 }: Props) => {
 
     const { sendGaEvent } = useGoogleAnalytics()
-    const { extensionId, cryptoSymbols, iconsPath, showTerms } = useRouteLoaderData('root') as LoaderData
+    const { extensionId, cryptoSymbols, showTerms } = useRouteLoaderData('root') as LoaderData
     const [fallbackLogo, setFallbackLogo] = useState(fallbackLogoProp || '')
     const [showingTerms, setShowingTerms] = useState(false)
     const { t } = useTranslation()

--- a/src/components/Modals/RewardsModal/RewardsModal.tsx
+++ b/src/components/Modals/RewardsModal/RewardsModal.tsx
@@ -23,7 +23,7 @@ interface Props extends Omit<ComponentProps<typeof Modal>, 'children'> {
 // }
 
 const RewardsModal = ({ open, closeFn, eligibleTokenAmount, currentCryptoSymbol }: Props): JSX.Element => {
-    const { platform, iconsPath, userId, flowId } = useRouteLoaderData('root') as LoaderData
+    const { platform, userId, flowId } = useRouteLoaderData('root') as LoaderData
     const { walletAddress } = useWalletAddress()
     const { t } = useTranslation()
 

--- a/src/components/Modals/StatusModal/StatusModal.tsx
+++ b/src/components/Modals/StatusModal/StatusModal.tsx
@@ -66,7 +66,6 @@ const Success = ({ closeFn }: StatusProps) => {
 
 
 const Failure = ({ closeFn }: StatusProps) => {
-    const { iconsPath } = useRouteLoaderData('root') as LoaderData
     const { t } = useTranslation()
 
     return (

--- a/src/components/Modals/StatusModal/StatusModal.tsx
+++ b/src/components/Modals/StatusModal/StatusModal.tsx
@@ -1,7 +1,6 @@
 import styles from './styles.module.css'
 import { ComponentProps } from 'react'
 import Modal from '../../Modal/Modal'
-import { useRouteLoaderData } from 'react-router-dom'
 import message from '../../../utils/message'
 import { useTranslation } from 'react-i18next'
 import { Oval } from 'react-loader-spinner'
@@ -44,7 +43,6 @@ const Loading = () => {
 }
 
 const Success = ({ closeFn }: StatusProps) => {
-    const { iconsPath } = useRouteLoaderData('root') as LoaderData
     const { t } = useTranslation()
     return (
         <div className={styles.card}>

--- a/src/components/Rewards/Rewards.tsx
+++ b/src/components/Rewards/Rewards.tsx
@@ -24,7 +24,7 @@ const Rewards = () => {
     const { sendGaEvent } = useGoogleAnalytics()
     const queryClient = useQueryClient()
     const [searchParams] = useSearchParams()
-    const { platform, iconsPath, cryptoSymbols, userId, flowId, autoclaim } = useRouteLoaderData('root') as LoaderData
+    const { platform, cryptoSymbols, userId, flowId, autoclaim } = useRouteLoaderData('root') as LoaderData
     const { walletAddress } = useWalletAddress()
     const [modalState, setModalState] = useState('close')
     const [loginModalState, setLoginModalState] = useState('close')

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,7 +1,6 @@
 import styles from './styles.module.css'
 // hooks
 import { Fragment, MouseEvent, useEffect, useId, useState } from "react"
-import { useRouteLoaderData } from 'react-router-dom'
 
 // components
 import Select, {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -138,7 +138,6 @@ const CustomNoOptionsMessage = (props: NoticeProps<ReactSelectOptionType>) => {
 }
 
 const CustomControl = (props: ControlProps<ReactSelectOptionType>) => {
-    const { iconsPath } = useRouteLoaderData('root') as LoaderData
     return (
         <components.Control {...props}>
             <Icon

--- a/src/pages/FrequentlyAskedQuestion/FrequentlyAskedQuestion.tsx
+++ b/src/pages/FrequentlyAskedQuestion/FrequentlyAskedQuestion.tsx
@@ -61,7 +61,7 @@ const AnswerParser: FC<AnswerParserProps> = ({ answer, links, indentationMark })
 
 const FrequentlyAskedQuestion = () => {
   const navigate = useNavigate()
-  const { iconsPath, walletAddress, platform, userId, flowId } = useRouteLoaderData('root') as LoaderData
+  const { walletAddress, platform, userId, flowId } = useRouteLoaderData('root') as LoaderData
   const { sendGaEvent } = useGoogleAnalytics()
   const { t } = useTranslation()
   const [currentIndex, setCurrentIndex] = useState(-1)

--- a/src/pages/History/Desktop/History.tsx
+++ b/src/pages/History/Desktop/History.tsx
@@ -37,8 +37,6 @@ interface ClaimsRes {
 }
 
 const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, totalEstimatedUsd, imgBg, retailerName = 'Total claims', description }: RowProps): JSX.Element => {
-    const { iconsPath } = useRouteLoaderData('root') as LoaderData
-
     return (
         <div id="history-desktop-row" className={`${styles.collapsible} ${isActive ? styles.collapsible_open : ''}`}>
             <div

--- a/src/pages/History/Mobile/History.tsx
+++ b/src/pages/History/Mobile/History.tsx
@@ -37,8 +37,6 @@ interface ClaimsRes {
 }
 
 const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, totalEstimatedUsd, imgBg, retailerName = 'Total claims', description }: RowProps): JSX.Element => {
-    const { iconsPath } = useRouteLoaderData('root') as LoaderData
-
     return (
         <div id="history-mobile-row" className={`${styles.collapsible} ${isActive ? styles.collapsible_open : ''}`}>
             <div


### PR DESCRIPTION
Fixes TS6133 errors by removing iconsPath from useRouteLoaderData destructuring in components where it was declared but never read.