### PR TITLE
fix(WalletAddressContext): drop strict `to: 'bringweb3'` message gate

### DIFF
--- a/src/context/WalletAddressContext.tsx
+++ b/src/context/WalletAddressContext.tsx
@@ -18,11 +18,8 @@ export function WalletProvider({ children, initialWalletAddress, initIsTester }:
     useEffect(() => {
         const handleMessage = async (event: MessageEvent) => {
             const data = event.data
-            // Validate message shape and tag before trusting the payload.
-            // The portal protocol requires partner-originated messages to
-            // carry `to: 'bringweb3'` so unrelated frames/scripts cannot
-            // trigger session refreshes.
-            if (!data || typeof data !== 'object' || data.to !== 'bringweb3') return
+            // Validate message shape before trusting the payload.
+            if (!data || typeof data !== 'object') return
             // `SESSION_UPDATE` is the current name; `WALLET_ADDRESS_UPDATE` is
             // kept as a legacy alias so existing partner integrations keep
             // working. Both carry the same `{ token }` payload.


### PR DESCRIPTION
Commit 68ffa37 required incoming postMessages to carry `to: 'bringweb3'`, which broke partner integrations that post SESSION_UPDATE without that tag — leaving walletAddress null and showing the Connect modal even when the wallet is connected. Drop the tag check; keep the payload shape validation.