### PR TITLE
chore(header): update support URL domain to bring.network

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,7 +8,7 @@ const Header = () => {
     const { t } = useTranslation()
     const { platform } = useRouteLoaderData('root') as LoaderData
     const { walletAddress } = useWalletAddress()
-    const supportUrl = `https://support.bringweb3.io/?platform=${platform}&address=${walletAddress}&env=${ENV}`
+    const supportUrl = `https://support.bring.network/?platform=${platform}&address=${walletAddress}&env=${ENV}`
 
     return (
         <div className={styles.header}>


### PR DESCRIPTION
This pull request makes a minor update to the support URL in the `Header` component, changing the domain from `support.bringweb3.io` to `support.bring.network`. This ensures users are directed to the correct support site.

- Updated the `supportUrl` in `Header.tsx` to use the new `support.bring.network` domain.