### PR TITLE
fix(dev-wrapper): send COSE_Key instead of address in ADA wallet sign…

### DIFF
--- a/dev-wrapper/yoroiWallet.ts
+++ b/dev-wrapper/yoroiWallet.ts
@@ -197,7 +197,7 @@ export function createYoroiWallet(opts: YoroiWalletOptions = {}): MockWallet {
             // the signature through as-is; the partner backend decodes it.
             const result: SignResult = {
                 signature: rawResponse.signature,
-                key: address!,
+                key: rawResponse.key,
                 message,
             }
             opts.onSign?.(result)


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/378

ADA wallet's signMessage was placing the Bech32 wallet address in the `key` field of the SignResult, causing backend signature verification to fail. Per CIP-30, api.signData() returns { signature, key } where `key` is the hex-encoded COSE_Key needed to verify the COSE_Sign1 signature. Forward rawResponse.key through unchanged so the backend can verify the claim.