### PR TITLE
fix(history): match "cancelled" status spelling from API

### DIFF
--- a/src/pages/History/helpers.ts
+++ b/src/pages/History/helpers.ts
@@ -50,7 +50,7 @@ export const formatStatus = (status: string, eligibleDate?: string) => {
             return "Completed";
         case "pending":
             return `In ${days} ${days && days > 1 ? "days" : "day"}`;
-        case "canceled":
+        case "cancelled":
             return "Canceled";
         default:
             return `In ${days} ${days && days > 1 ? "days" : "day"}`;


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/368

The formatStatus switch was checking for "canceled" (US spelling) but the API returns "cancelled" (UK spelling), causing cancelled transactions to fall through to the default branch and display an incorrect "In X day(s)" label instead of "Canceled".

It's better to fix it on Portal's side as there're external partners who also use the backend API.