### PR TITLE
chore(dev-wrapper): relabel Solflare option as USDC

### DIFF
--- a/dev-wrapper/index.html
+++ b/dev-wrapper/index.html
@@ -58,7 +58,7 @@
                         <select id="walletProvider">
                             <option value="mock">Mock (in-page)</option>
                             <option value="nightly">Nightly (Solana)</option>
-                            <option value="solflare">Solflare (Solana)</option>
+                            <option value="solflare">Solflare (USDC)</option>
                             <option value="yoroi">Yoroi (Cardano)</option>
                             <option value="casper">Casper Wallet (CSPR)</option>
                             <option value="ecko">Ecko (Kadena, connect only)</option>


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/386

This pull request makes a minor wording update to the wallet provider dropdown in the `dev-wrapper/index.html` file, clarifying that the "Solflare" option is for USDC.

- Changed the label for the Solflare wallet provider option from "Solflare (Solana)" to "Solflare (USDC)" in the wallet provider dropdown to better reflect its supported currency.