### PR TITLE
Dev wrapper tooling

### DIFF
--- a/dev-wrapper/.env.example
+++ b/dev-wrapper/.env.example
@@ -1,8 +1,30 @@
 # Dev API endpoint for POST .../v1/extension/check/portal
 VITE_PORTAL_API=https://api.bringweb3.io/portal-teset/v1/extension/check/portal
 
-# Partner API key (sent as the x-api-key header). Get one from the Bring team.
+# Default / fallback partner API key (sent as the x-api-key header).
+# Used whenever the selected provider has no key of its own (e.g. mock).
+# Set it to whichever platform key you want as the catch-all default.
 VITE_PORTAL_API_KEY=replace-me
+
+# Per-provider API keys. The active one is chosen by the "Wallet provider"
+# input in the dev wrapper. Anything left unset falls back to VITE_PORTAL_API_KEY.
+# (mock has no key of its own and uses the fallback.)
+VITE_PORTAL_API_KEY_NIGHTLY=replace-me
+VITE_PORTAL_API_KEY_SOLFLARE=replace-me
+VITE_PORTAL_API_KEY_YOROI=replace-me
+VITE_PORTAL_API_KEY_CASPER=replace-me
+VITE_PORTAL_API_KEY_ECKO=replace-me
+VITE_PORTAL_API_KEY_READY=replace-me
+
+# Optional per-provider API URL overrides (same switching by "Wallet provider").
+# Unset => falls back to VITE_PORTAL_API above.
+# VITE_PORTAL_API_NIGHTLY=https://api.bringweb3.io/<stage>/v1/extension/check/portal
+# VITE_PORTAL_API_SOLFLARE=...
+# VITE_PORTAL_API_YOROI=...
+# VITE_PORTAL_API_CASPER=...
+# VITE_PORTAL_API_ECKO=...
+# VITE_PORTAL_API_READY=...
+# VITE_PORTAL_API_MOCK=...
 
 # Your Chrome extension ID (only meaningful if you also use the Bring extension kit).
 VITE_PORTAL_EXTENSION_ID=replace-me
@@ -16,3 +38,18 @@ VITE_PORTAL_LOCAL_URL=http://localhost:5173
 
 # Wallet address used on login simulation.
 VITE_PORTAL_WALLET=0x1111111111111111111111111111111111111111
+
+# Default theme injected into the dev wrapper's theme selector on load.
+# Valid values: "dark", "light", or "unset" (omit / empty = let the portal/API decide).
+VITE_PORTAL_THEME=unset
+
+# Figma personal access token (server-side only, NOT exposed to the browser).
+# Used by the dev-wrapper's /__figma-image proxy so the visual-diff overlay can
+# load a frame straight from a Figma link. Create one at
+# https://www.figma.com/developers/api#access-tokens
+FIGMA_TOKEN=replace-me
+
+# Visual-diff overlay start state. The overlay is always available; this flag
+# only controls whether it starts expanded ("1"/"true") or collapsed (anything
+# else / unset).
+# VITE_VISUAL_DIFF=1

--- a/dev-wrapper/.gitignore
+++ b/dev-wrapper/.gitignore
@@ -1,0 +1,4 @@
+# Environment files — keep .env.example as the tracked template
+.env
+.env.*
+!.env.example

--- a/dev-wrapper/README.md
+++ b/dev-wrapper/README.md
@@ -9,7 +9,10 @@ implement.
 
 1. Reads `theme`, `walletAddress`, `extensionId` from the controls.
 2. Calls `POST $VITE_PORTAL_API` (the dev `check/portal` endpoint) with
-   `x-api-key: $VITE_PORTAL_API_KEY`.
+   `x-api-key: $VITE_PORTAL_API_KEY`. The URL and key actually used are
+   chosen by the **Wallet provider** selector — see
+   [Per-provider API](#per-provider-api). The active API path (stage) is
+   shown read-only above the Inputs.
 3. On the first response, sets the iframe `src` from `portalUrl` (the JWT is
    already embedded in its query string — no `postMessage` needed). The
    legacy `iframeUrl` field is ignored.
@@ -42,11 +45,29 @@ yarn install
 
 | Var | Purpose |
 | --- | --- |
-| `VITE_PORTAL_API` | Full URL of the `check/portal` endpoint. |
-| `VITE_PORTAL_API_KEY` | Partner `x-api-key` header. |
+| `VITE_PORTAL_API` | Full URL of the `check/portal` endpoint (default / fallback). |
+| `VITE_PORTAL_API_KEY` | Partner `x-api-key` header (default / fallback, used when the selected provider has no key of its own — e.g. `mock`). |
+| `VITE_PORTAL_API_KEY_<PROVIDER>` | Per-provider `x-api-key`, picked by the **Wallet provider** selector. `<PROVIDER>` ∈ `NIGHTLY`, `SOLFLARE`, `YOROI`, `CASPER`, `ECKO`, `READY`. Falls back to `VITE_PORTAL_API_KEY` when unset. |
+| `VITE_PORTAL_API_<PROVIDER>` | Optional per-provider API URL override (same `<PROVIDER>` values). Falls back to `VITE_PORTAL_API` when unset. |
 | `VITE_PORTAL_EXTENSION_ID` | Default value for the Extension ID input. |
 | `VITE_PORTAL_LOCAL_URL` | If set, the wrapper rewrites the iframe origin to this URL while keeping the `?token=…` query — lets you iterate on the local portal while still using a real dev token. Leave empty to use the API's `iframeUrl` as-is. |
 | `VITE_PORTAL_WALLET` | Optional default wallet address used by the mock wallet on auto-connect. Leave empty for a random throwaway address. |
+| `VITE_VISUAL_DIFF` | Start state of the [visual-diff overlay](#visual-diff-overlay). The overlay is **always available**; `1`/`true` starts it expanded, anything else (or unset) starts it collapsed. |
+| `FIGMA_TOKEN` | Server-side Figma personal access token (never exposed to the browser). Lets the overlay's **Figma** field render a frame straight from a Figma link via the dev `/__figma-image` proxy. Create one at <https://www.figma.com/developers/api#access-tokens>. |
+
+### Per-provider API
+
+The **Wallet provider** selector picks both the simulated wallet adapter and
+the API the wrapper talks to. For the selected provider `P`, the wrapper
+resolves:
+
+- URL: `VITE_PORTAL_API_<P>` → falls back to `VITE_PORTAL_API`.
+- Key: `VITE_PORTAL_API_KEY_<P>` → falls back to `VITE_PORTAL_API_KEY`.
+
+So you only need to set the per-provider vars for platforms that differ; the
+plain `VITE_PORTAL_API` / `VITE_PORTAL_API_KEY` act as the default (and are
+what `mock` uses). Changing the selector re-bootstraps a fresh session and
+reloads the iframe.
 
 ## Run
 
@@ -70,6 +91,11 @@ Open <http://localhost:5174>.
 - **Header / wallet button** — top-right. Click to connect (sends
   `SESSION_UPDATE`) or, when connected, click the short `0xab12…cdef`
   pill to disconnect.
+- **Sidebar — Wallet provider** — selects which wallet adapter to simulate and
+  which API URL/key to use (see [Per-provider API](#per-provider-api)).
+  Switching it starts a brand-new portal session and reloads the iframe.
+- **Sidebar — API path** — read-only text above the Inputs showing the active
+  API stage. It's set from the env on deploy, not editable in the UI.
 - **Sidebar — Inputs** — theme / wallet / extension ID + Refresh. Changing any
   value re-calls the API and posts the new token to the iframe.
 - **Sidebar — Mock wallet SDK** — toggles for *Start disconnected*,
@@ -82,6 +108,50 @@ Open <http://localhost:5174>.
   the last `portalUrl` and decoded JWT payload.
 - **Toggle button** on the sidebar edge collapses the controls to give the
   iframe full width.
+
+## Visual diff overlay
+
+A dev-only tool for pixel-comparing the running page against a design. It lays
+a semi-transparent image over the wrapper page so you can check spacing, sizes
+and colours against a Figma frame. It's always mounted; `VITE_VISUAL_DIFF`
+only controls whether it starts expanded or collapsed (see env vars above).
+State (image, position, scale, toggles) is persisted to `localStorage`.
+
+The overlay ships in the hosted build too. Image-by-**URL**, **File** picker and
+drag & drop work anywhere. The **Figma** loader needs a token: locally it uses
+the server-side `FIGMA_TOKEN` via the `/__figma-image` proxy; on the hosted site
+(no proxy) paste a token into the overlay's **Token** field and it calls the
+Figma API directly from the browser. That token stays in your browser's
+`localStorage` and is never part of the build.
+
+When collapsed it sits as a slim vertical **Visual diff** tab pinned to the
+right edge; click it to expand the control panel (use the `▾` button to
+collapse again).
+
+### Loading an image
+
+| Control | What it does |
+| --- | --- |
+| **Figma** field + `load` | Paste a Figma design link (`figma.com/design/…?node-id=…`) and click `load`. Locally (with `FIGMA_TOKEN` set) it resolves the node to a PNG via the dev `/__figma-image` proxy. If you fill the **Token** field, it calls the Figma API directly from the browser instead — which is what makes this work on the hosted build (where the proxy doesn't exist). |
+| **Token** field | Optional Figma personal access token. Stored only in this browser's `localStorage` (key `bring.visualDiff.figmaToken`), sent only as the `X-Figma-Token` header on direct Figma API calls. Use this on the hosted site; leave empty locally to use the proxy/`FIGMA_TOKEN`. Create one at <https://www.figma.com/developers/api#access-tokens>. |
+| **URL** field | Paste a direct image URL (`https://…` or a `data:` URI). Used as-is — no Figma API. |
+| **File** picker | Choose a local image (PNG / JPEG / WebP). |
+| **Drop box** / drag & drop | Drop an image file or a Figma asset onto the box (or anywhere on the page). Only active while the overlay is visible and movable. |
+
+### Positioning & comparison
+
+| Control | What it does |
+| --- | --- |
+| **X / Y** | Overlay position in px. You can also drag the image directly (when movable) or nudge with arrow keys (`shift` = 10px). |
+| **Scale** | Manual scale factor. |
+| **Opacity** | Overlay transparency. |
+| `diff` | Toggles `mix-blend-mode: difference` — matching pixels go **black**, mismatches show bright/coloured. |
+| `border` | Toggles a magenta outline around the image so its bounds are visible (doesn't shift size/position). |
+| `fit` | Scales the image to the iframe width and centers it. **Toggle** — click again to restore the previous size/position. |
+| `center` | Centers horizontally over the iframe without changing scale. |
+| `hide` / `show` | Hides/shows the overlay image (panel stays). |
+| `🔓 movable` / `🔒 locked` | Locks the overlay so it ignores pointer events (and disables dragging). |
+| `reset` | Clears the overlay back to defaults. |
 
 ## Protocol cheatsheet
 

--- a/dev-wrapper/README.md
+++ b/dev-wrapper/README.md
@@ -47,8 +47,8 @@ yarn install
 | --- | --- |
 | `VITE_PORTAL_API` | Full URL of the `check/portal` endpoint (default / fallback). |
 | `VITE_PORTAL_API_KEY` | Partner `x-api-key` header (default / fallback, used when the selected provider has no key of its own — e.g. `mock`). |
-| `VITE_PORTAL_API_KEY_<PROVIDER>` | Per-provider `x-api-key`, picked by the **Wallet provider** selector. `<PROVIDER>` ∈ `NIGHTLY`, `SOLFLARE`, `YOROI`, `CASPER`, `ECKO`, `READY`. Falls back to `VITE_PORTAL_API_KEY` when unset. |
-| `VITE_PORTAL_API_<PROVIDER>` | Optional per-provider API URL override (same `<PROVIDER>` values). Falls back to `VITE_PORTAL_API` when unset. |
+| `VITE_PORTAL_API_KEY_<PROVIDER>` | Per-provider `x-api-key`, picked by the **Wallet provider** selector. `<PROVIDER>` ∈ `MOCK`, `NIGHTLY`, `SOLFLARE`, `YOROI`, `CASPER`, `ECKO`, `READY`. Falls back to `VITE_PORTAL_API_KEY` when unset. |
+| `VITE_PORTAL_API_<PROVIDER>` | Optional per-provider API URL override (same `<PROVIDER>` values, including `MOCK`). Falls back to `VITE_PORTAL_API` when unset. |
 | `VITE_PORTAL_EXTENSION_ID` | Default value for the Extension ID input. |
 | `VITE_PORTAL_LOCAL_URL` | If set, the wrapper rewrites the iframe origin to this URL while keeping the `?token=…` query — lets you iterate on the local portal while still using a real dev token. Leave empty to use the API's `iframeUrl` as-is. |
 | `VITE_PORTAL_WALLET` | Optional default wallet address used by the mock wallet on auto-connect. Leave empty for a random throwaway address. |

--- a/dev-wrapper/index.html
+++ b/dev-wrapper/index.html
@@ -3,8 +3,9 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="robots" content="noindex, nofollow, noarchive, nosnippet" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <title>Cashback Portal — dev wrapper</title>
+        <title>Cashback Portal - dev wrapper</title>
         <link rel="stylesheet" href="./style.css" />
     </head>
     <body>
@@ -19,6 +20,9 @@
             <button id="walletBtn" type="button" class="wallet-btn" data-state="disconnected">
                 Connect wallet
             </button>
+            <button id="logoutBtn" type="button" class="logout-btn" title="Clear CloudFront basic-auth credentials" hidden>
+                Log out
+            </button>
         </header>
 
         <main class="layout" id="layout">
@@ -26,6 +30,8 @@
                 <span class="toggle-icon" aria-hidden="true">‹</span>
             </button>
             <aside class="controls">
+                <p class="api-info">API path: <code id="apiStageInfo">—</code></p>
+
                 <fieldset>
                     <legend>Inputs</legend>
 

--- a/dev-wrapper/main.ts
+++ b/dev-wrapper/main.ts
@@ -493,7 +493,7 @@ async function bootstrap(walletAddress: string | null): Promise<PortalApiRespons
     const apiUrl = getApiUrl()
     const apiKey = getApiKey()
     if (!apiUrl || !apiKey) {
-        setStatus(`Missing API URL or key for provider "${activeProvider}" (set VITE_PORTAL_API[_KEY] in .env.local)`, true)
+        setStatus(`Missing API URL or key for provider "${activeProvider}" (set VITE_PORTAL_API / VITE_PORTAL_API_KEY, or the per-provider overrides VITE_PORTAL_API_<PROVIDER> / VITE_PORTAL_API_KEY_<PROVIDER>, in .env.local)`, true)
         return null
     }
 

--- a/dev-wrapper/main.ts
+++ b/dev-wrapper/main.ts
@@ -8,6 +8,18 @@ import { createCasperWallet } from './casperWallet'
 import { createEckoWallet } from './eckoWallet'
 import { createReadyWallet } from './readyWallet'
 import { createPortalBridge, type LogKind } from './portalBridge'
+import { mountVisualDiffOverlay } from './visualDiffOverlay'
+
+// The visual-diff overlay is an authoring aid for pixel-comparing the page
+// against a design. It's included in the hosted build too: the URL/file/drag
+// loaders are pure client-side, and the Figma loader works either via the
+// dev-only `/__figma-image` proxy (local, using the server FIGMA_TOKEN) or by
+// a Figma token pasted into the overlay (which stays in the browser). No
+// secret is ever baked into the build. VITE_VISUAL_DIFF controls whether it
+// starts expanded (1/true).
+mountVisualDiffOverlay({
+    startExpanded: import.meta.env.VITE_VISUAL_DIFF === '1' || import.meta.env.VITE_VISUAL_DIFF === 'true',
+})
 
 type Theme = 'light' | 'dark'
 
@@ -21,11 +33,48 @@ interface PortalApiResponse {
 
 const env = import.meta.env
 
-const API_URL = env.VITE_PORTAL_API as string | undefined
+// Shared/default API config. Used as a fallback when a provider-specific
+// override isn't set.
+const API_BASE = env.VITE_PORTAL_API as string | undefined
 const API_KEY = env.VITE_PORTAL_API_KEY as string | undefined
+
+// Per-provider API config keyed by the wallet-provider id (the values of the
+// "Wallet provider" <select>). Each platform/partner has its own API key (and
+// optionally its own API URL). Anything left unset falls back to the shared
+// VITE_PORTAL_API / VITE_PORTAL_API_KEY above.
+const PROVIDER_API: Record<string, { url?: string; key?: string }> = {
+    mock: { url: env.VITE_PORTAL_API_MOCK, key: env.VITE_PORTAL_API_KEY_MOCK },
+    nightly: { url: env.VITE_PORTAL_API_NIGHTLY, key: env.VITE_PORTAL_API_KEY_NIGHTLY },
+    solflare: { url: env.VITE_PORTAL_API_SOLFLARE, key: env.VITE_PORTAL_API_KEY_SOLFLARE },
+    yoroi: { url: env.VITE_PORTAL_API_YOROI, key: env.VITE_PORTAL_API_KEY_YOROI },
+    casper: { url: env.VITE_PORTAL_API_CASPER, key: env.VITE_PORTAL_API_KEY_CASPER },
+    ecko: { url: env.VITE_PORTAL_API_ECKO, key: env.VITE_PORTAL_API_KEY_ECKO },
+    ready: { url: env.VITE_PORTAL_API_READY, key: env.VITE_PORTAL_API_KEY_READY },
+}
+
+// The API URL has the shape `https://host/<stage>/v1/extension/check/portal`.
+// The `<stage>` segment is fixed at build time and is shown read-only in the UI
+// for information only.
+const stageOf = (url?: string): string => {
+    if (!url) return ''
+    try {
+        return new URL(url).pathname.split('/').filter(Boolean)[0] ?? ''
+    } catch {
+        return ''
+    }
+}
+
+const defaultStage = stageOf(API_BASE)
+
+const apiStage = defaultStage
+// Resolved against the currently selected wallet provider at call time.
+const getApiUrl = (): string | undefined => PROVIDER_API[activeProvider]?.url || API_BASE
+const getApiKey = (): string | undefined => PROVIDER_API[activeProvider]?.key || API_KEY
+
 const DEFAULT_EXT_ID = (env.VITE_PORTAL_EXTENSION_ID as string | undefined) ?? ''
 const LOCAL_PORTAL_URL = (env.VITE_PORTAL_LOCAL_URL as string | undefined) ?? ''
 const DEFAULT_WALLET = (env.VITE_PORTAL_WALLET as string | undefined) ?? ''
+const DEFAULT_THEME = ((env.VITE_PORTAL_THEME as string | undefined) ?? '').trim().toLowerCase()
 
 const $ = <T extends HTMLElement>(id: string) => {
     const el = document.getElementById(id)
@@ -36,6 +85,7 @@ const $ = <T extends HTMLElement>(id: string) => {
 const themeEl = $<HTMLSelectElement>('theme')
 const walletEl = $<HTMLInputElement>('wallet')
 const extensionEl = $<HTMLInputElement>('extensionId')
+const apiStageInfoEl = $<HTMLElement>('apiStageInfo')
 const refreshBtn = $<HTMLButtonElement>('refresh')
 const iframeEl = $<HTMLIFrameElement>('portal')
 const lastUrlEl = $<HTMLTextAreaElement>('lastUrl')
@@ -48,6 +98,8 @@ const startDisconnectedDefault = localStorage.getItem(STARTED_DISCONNECTED_KEY) 
 
 extensionEl.value = DEFAULT_EXT_ID
 walletEl.value = startDisconnectedDefault ? '' : DEFAULT_WALLET
+themeEl.value = DEFAULT_THEME === 'dark' || DEFAULT_THEME === 'light' ? DEFAULT_THEME : ''
+apiStageInfoEl.textContent = apiStage || '(default)'
 
 const layoutEl = $<HTMLElement>('layout')
 const toggleBtn = $<HTMLButtonElement>('toggleSidebar')
@@ -71,6 +123,29 @@ const walletBtn = $<HTMLButtonElement>('walletBtn')
 const walletProviderEl = $<HTMLSelectElement>('walletProvider')
 const logEl = $<HTMLDivElement>('log')
 const clearLogBtn = $<HTMLButtonElement>('clearLog')
+
+// "Log out" clears the CloudFront HTTP basic-auth credentials the browser has
+// cached for this origin. It only makes sense on the hosted build (the local
+// dev server isn't password-protected), so the button stays hidden on
+// localhost / 127.0.0.1.
+const logoutBtn = $<HTMLButtonElement>('logoutBtn')
+const isLocalHost = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]'].includes(location.hostname)
+if (!isLocalHost) {
+    logoutBtn.hidden = false
+    logoutBtn.addEventListener('click', () => {
+        // Overwrite the stored Basic-Auth credentials with bogus ones so the
+        // browser drops the cached pair for this realm, then reload to force a
+        // fresh 401 / credentials prompt.
+        try {
+            const xhr = new XMLHttpRequest()
+            xhr.open('GET', location.href, true, 'logout', String(Date.now()))
+            xhr.onloadend = () => location.reload()
+            xhr.send()
+        } catch {
+            location.reload()
+        }
+    })
+}
 
 function appendLog(kind: LogKind, label: string, payload?: unknown) {
     const entry = document.createElement('div')
@@ -183,6 +258,8 @@ const getReadyAdapter = (): MockWallet => {
 const initialProvider = (localStorage.getItem(WALLET_PROVIDER_KEY) as WalletProviderId | null) ?? 'mock'
 walletProviderEl.value = initialProvider
 let activeProvider: WalletProviderId = initialProvider
+// Now that the active provider is known, show its API stage.
+apiStageInfoEl.textContent = stageOf(getApiUrl()) || '(default)'
 
 const pickAdapter = (): MockWallet => {
     switch (activeProvider) {
@@ -227,6 +304,11 @@ walletProviderEl.addEventListener('change', async () => {
     localStorage.setItem(WALLET_PROVIDER_KEY, activeProvider)
     appendLog('info', `Wallet provider → ${activeProvider}`)
     applyProviderUi()
+    // Switching provider = new platform/API key = brand-new portal session:
+    // reflect the (possibly different) stage and force a full iframe reload.
+    apiStageInfoEl.textContent = stageOf(getApiUrl()) || '(default)'
+    isFirstLoad = true
+    void refresh()
 })
 
 const bridge = createPortalBridge({
@@ -408,8 +490,10 @@ function buildIframeSrc(returnedUrl: string, token: string): string {
 }
 
 async function bootstrap(walletAddress: string | null): Promise<PortalApiResponse | null> {
-    if (!API_URL || !API_KEY) {
-        setStatus('Missing VITE_PORTAL_API or VITE_PORTAL_API_KEY in .env.local', true)
+    const apiUrl = getApiUrl()
+    const apiKey = getApiKey()
+    if (!apiUrl || !apiKey) {
+        setStatus(`Missing API URL or key for provider "${activeProvider}" (set VITE_PORTAL_API[_KEY] in .env.local)`, true)
         return null
     }
 
@@ -426,10 +510,10 @@ async function bootstrap(walletAddress: string | null): Promise<PortalApiRespons
 
     let res: Response
     try {
-        res = await fetch(API_URL, {
+        res = await fetch(apiUrl, {
             method: 'POST',
             headers: {
-                'x-api-key': API_KEY,
+                'x-api-key': apiKey,
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(body),

--- a/dev-wrapper/package.json
+++ b/dev-wrapper/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "yarn build && aws s3 sync dist s3://portal-viewer.bringweb3.io --delete --exclude index.html --cache-control \"public,max-age=31536000,immutable\" && aws s3 cp dist/index.html s3://portal-viewer.bringweb3.io/index.html --cache-control \"no-cache\" --content-type \"text/html; charset=utf-8\" && aws cloudfront create-invalidation --distribution-id E1LQKQMDXNNDKB --paths \"/*\""
   },
   "devDependencies": {
     "typescript": "^5.5.4",

--- a/dev-wrapper/public/robots.txt
+++ b/dev-wrapper/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/dev-wrapper/style.css
+++ b/dev-wrapper/style.css
@@ -37,6 +37,21 @@ html, body {
     font-size: 11px;
 }
 
+.api-info {
+    margin: -6px 0 12px;
+    font-size: 10px;
+    color: #8a93a3;
+}
+
+.api-info code {
+    background: #1a1f27;
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 10px;
+    color: #3ddc84;
+    font-weight: 700;
+}
+
 .wallet-btn {
     background: #3d5aeb;
     color: #fff;
@@ -60,6 +75,33 @@ html, body {
 }
 
 .wallet-btn[data-state="connected"]:hover { background: #1f2530; }
+
+.logout-btn {
+    margin-left: 4px;
+    padding-left: 16px;
+    border-left: 1px solid #2a313c;
+    background: transparent;
+    color: #8a93a3;
+    border-top: 0;
+    border-right: 0;
+    border-bottom: 0;
+    border-radius: 0;
+    font-size: 11px;
+    font-weight: 500;
+    font-family: inherit;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.logout-btn::before {
+    content: "⏻ ";
+    font-size: 12px;
+}
+
+.logout-btn:hover { color: #e7e9ee; }
+.logout-btn[hidden] { display: none; }
 
 .layout {
     position: relative;

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -1,0 +1,617 @@
+/**
+ * Dev-only visual-diff overlay for the dev-wrapper.
+ *
+ * Drop a Figma PNG export over the running wrapper page to pixel-compare
+ * layouts. Enable by adding `?visualDiff=1` to the URL (the flag is then
+ * persisted to localStorage so reloads keep it on).
+ *
+ * Controls:
+ *   - File picker, URL field, or drag & drop to load an image (drop a PNG
+ *     from disk, or drag an image straight out of Figma / another tab)
+ *   - X / Y / scale / opacity inputs
+ *   - Drag the overlay image to position it (arrow keys nudge 1px,
+ *     shift+arrows 10px)
+ *   - `diff` toggles `mix-blend-mode: difference` (matching pixels go black)
+ *   - `hide` / `lock` / `reset`
+ *
+ * Note: this overlays the dev-wrapper page itself, NOT the portal inside the
+ * iframe. To overlay the portal, open the portal directly with `?visualDiff=1`
+ * (the React mount in `src/dev/VisualDiffOverlay.tsx` handles that case).
+ */
+
+type State = {
+    src: string
+    x: number
+    y: number
+    scale: number
+    opacity: number
+    diff: boolean
+    visible: boolean
+    locked: boolean
+    collapsed: boolean
+    border: boolean
+}
+
+const STORAGE_KEY = 'bring.visualDiff.wrapper.v1'
+// The Figma personal access token is a credential, so it's kept out of the
+// persisted overlay STATE and stored under its own key. It never leaves the
+// browser except as the `X-Figma-Token` header on direct calls to the Figma
+// REST API (used when the dev-only `/__figma-image` proxy isn't available,
+// e.g. on the static hosted build).
+const FIGMA_TOKEN_KEY = 'bring.visualDiff.figmaToken'
+
+// Pull the file key + node id out of a Figma URL (design/file/board/proto).
+const parseFigmaUrl = (url: string): { fileKey: string; nodeId: string } | null => {
+    const fileMatch = url.match(/figma\.com\/(?:file|design|board|proto)\/([A-Za-z0-9]+)/)
+    const nodeMatch = url.match(/[?&]node-id=([0-9]+[-:][0-9]+)/)
+    if (!fileMatch || !nodeMatch) return null
+    return { fileKey: fileMatch[1], nodeId: nodeMatch[1].replace('-', ':') }
+}
+const DEFAULTS: State = {
+    src: '',
+    x: 0,
+    y: 0,
+    scale: 1,
+    opacity: 0.5,
+    diff: false,
+    visible: true,
+    locked: false,
+    collapsed: false,
+    border: false,
+}
+
+const loadState = (): State => {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY)
+        if (!raw) return { ...DEFAULTS }
+        return { ...DEFAULTS, ...(JSON.parse(raw) as Partial<State>) }
+    } catch {
+        return { ...DEFAULTS }
+    }
+}
+
+export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) => {
+    let state = loadState()
+    // The flag decides the initial collapsed state on every load, so toggling
+    // VITE_VISUAL_DIFF reliably opens/closes the panel regardless of what was
+    // persisted last time.
+    state = { ...state, collapsed: !(opts.startExpanded ?? true) }
+    const save = () => localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+
+    // Snapshot of scale/x/y taken right before "fit" so a second click can
+    // restore it (toggle fit ⇄ unfit). Null = not currently fitted.
+    let preFit: { scale: number; x: number; y: number } | null = null
+
+    // Auto-fit the overlay to the portal iframe (scale image down/up so
+    // its width matches the iframe), then center it horizontally. Falls
+    // back to the viewport if the iframe isn't present.
+    const fitAndCenter = () => {
+        const apply = () => {
+            if (!img.naturalWidth) return
+            const portal = document.getElementById('portal') as HTMLIFrameElement | null
+            const rect = portal?.getBoundingClientRect()
+            const targetWidth = rect ? rect.width : window.innerWidth
+            const targetLeft = rect ? rect.left : 0
+            const scale = Number((targetWidth / img.naturalWidth).toFixed(4))
+            const w = img.naturalWidth * scale
+            state = { ...state, scale, x: Math.round(targetLeft + (targetWidth - w) / 2) }
+            syncUi()
+        }
+        if (img.complete && img.naturalWidth) apply()
+        else img.addEventListener('load', apply, { once: true })
+    }
+    // Center the overlay horizontally over the iframe without touching the
+    // current scale.
+    const centerXOnly = () => {
+        const apply = () => {
+            if (!img.naturalWidth) return
+            const portal = document.getElementById('portal') as HTMLIFrameElement | null
+            const rect = portal?.getBoundingClientRect()
+            const targetWidth = rect ? rect.width : window.innerWidth
+            const targetLeft = rect ? rect.left : 0
+            const w = img.naturalWidth * state.scale
+            state = { ...state, x: Math.round(targetLeft + (targetWidth - w) / 2) }
+            syncUi()
+        }
+        if (img.complete && img.naturalWidth) apply()
+        else img.addEventListener('load', apply, { once: true })
+    }
+
+    // --- overlay image -----------------------------------------------------
+    const img = document.createElement('img')
+    img.alt = ''
+    img.draggable = false
+    Object.assign(img.style, {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        transformOrigin: 'top left',
+        zIndex: '2147483646',
+        userSelect: 'none',
+    } as CSSStyleDeclaration)
+    document.body.appendChild(img)
+
+    const applyImg = () => {
+        if (!state.src || !state.visible) {
+            img.style.display = 'none'
+            return
+        }
+        img.style.display = ''
+        if (img.src !== state.src) img.src = state.src
+        img.style.top = `${state.y}px`
+        img.style.left = `${state.x}px`
+        img.style.transform = `scale(${state.scale})`
+        img.style.opacity = String(state.opacity)
+        img.style.mixBlendMode = state.diff ? 'difference' : 'normal'
+        // Outline (not border) so toggling it never shifts the image's size/pos.
+        img.style.outline = state.border ? '2px solid #FF2D9B' : 'none'
+        img.style.outlineOffset = state.border ? '-1px' : '0'
+        img.style.pointerEvents = state.locked ? 'none' : 'auto'
+        img.style.cursor = state.locked ? 'default' : 'move'
+    }
+
+    img.addEventListener('pointerdown', (e: PointerEvent) => {
+        if (state.locked) return
+        e.preventDefault()
+        // Capture the pointer on the image so we keep getting move events even
+        // when the cursor passes over the cross-origin portal iframe (which
+        // would otherwise swallow them and freeze the drag).
+        img.setPointerCapture(e.pointerId)
+        const startX = e.clientX
+        const startY = e.clientY
+        const baseX = state.x
+        const baseY = state.y
+        const move = (ev: PointerEvent) => {
+            state = { ...state, x: baseX + (ev.clientX - startX), y: baseY + (ev.clientY - startY) }
+            applyImg()
+            xInput.value = String(state.x)
+            yInput.value = String(state.y)
+        }
+        const up = (ev: PointerEvent) => {
+            img.removeEventListener('pointermove', move)
+            img.removeEventListener('pointerup', up)
+            img.removeEventListener('pointercancel', up)
+            try { img.releasePointerCapture(ev.pointerId) } catch { /* already released */ }
+            save()
+        }
+        img.addEventListener('pointermove', move)
+        img.addEventListener('pointerup', up)
+        img.addEventListener('pointercancel', up)
+    })
+
+    // --- control panel -----------------------------------------------------
+    const panel = document.createElement('div')
+    Object.assign(panel.style, {
+        position: 'fixed',
+        top: '64px',
+        right: '8px',
+        zIndex: '2147483647',
+        background: 'rgba(20,22,28,0.92)',
+        color: '#F5F8FF',
+        font: '12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace',
+        padding: '10px',
+        borderRadius: '8px',
+        border: '1px solid #2a2d33',
+        width: '240px',
+        boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+    } as CSSStyleDeclaration)
+    document.body.appendChild(panel)
+    panel.id = 'bring-visual-diff-panel'
+
+    // Inject hover/active styling for the panel buttons so they read as
+    // clickable (inline styles alone can't express :hover).
+    const styleTag = document.createElement('style')
+    styleTag.textContent = `
+        #bring-visual-diff-panel button { transition: filter 0.12s, transform 0.05s; }
+        #bring-visual-diff-panel button:hover { filter: brightness(1.25); }
+        #bring-visual-diff-panel button:active { transform: translateY(1px); }
+    `
+    document.head.appendChild(styleTag)
+
+    panel.innerHTML = `
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:6px">
+            <button data-act="collapse" title="Collapse / expand" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 7px;border-radius:4px;cursor:pointer;font:inherit;line-height:1">▾</button>
+            <strong data-el="title" style="flex:1">Visual diff (wrapper)</strong>
+            <button data-act="reset" data-el="resetBtn" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">reset</button>
+        </div>
+        <div data-el="body">
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">Figma</span>
+            <input type="text" data-el="figma" placeholder="figma.com/design/…?node-id=…" style="flex:1;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+            <button data-act="fetchFigma" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">load</button>
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">Token</span>
+            <input type="password" data-el="figmaToken" placeholder="Figma token (stored in this browser only)" autocomplete="off" style="flex:1;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+        </div>
+        <div data-el="figmaStatus" style="margin-top:4px;color:#9aa0a6;font-size:11px;min-height:14px"></div>
+        <div style="margin-top:6px"><input type="file" data-el="file" accept="image/png,image/jpeg,image/webp" style="font:inherit;color:#9aa0a6"></div>
+        <div data-el="dropzone" style="margin-top:6px;border:2px dashed #2a2d33;border-radius:6px;padding:10px;text-align:center;color:#9aa0a6;cursor:copy;font-size:11px">Drop image / Figma asset here</div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">URL</span>
+            <input type="text" data-el="url" placeholder="https://… or data:…" style="width:160px;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">X / Y</span>
+            <input type="number" data-el="x" style="width:64px;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+            <input type="number" data-el="y" style="width:64px;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">Scale</span>
+            <input type="number" step="0.05" data-el="scale" style="width:64px;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">Opacity</span>
+            <input type="range" min="0" max="1" step="0.05" data-el="opacity" style="flex:1">
+            <span data-el="opacityVal" style="width:30px;text-align:right"></span>
+        </div>
+        <div style="display:flex;align-items:center;gap:4px;margin-top:6px;flex-wrap:wrap">
+            <button data-act="diff" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">diff</button>
+            <button data-act="border" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Outline the overlay image so its bounds are visible">border</button>
+            <button data-act="fit" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Scale to iframe width and center">fit</button>
+            <button data-act="center" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Center horizontally (keep scale)">center</button>
+            <button data-act="visible" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">hide</button>
+            <button data-act="locked" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">lock</button>
+        </div>
+        <div style="margin-top:6px;color:#66686E;font-size:11px">arrows = 1px · shift+arrows = 10px</div>
+        </div>
+    `
+
+    const q = <T extends HTMLElement>(sel: string) => panel.querySelector(sel) as T
+    const fileInput = q<HTMLInputElement>('[data-el="file"]')
+    const dropzone = q<HTMLDivElement>('[data-el="dropzone"]')
+    const urlInput = q<HTMLInputElement>('[data-el="url"]')
+    const figmaInput = q<HTMLInputElement>('[data-el="figma"]')
+    const figmaTokenInput = q<HTMLInputElement>('[data-el="figmaToken"]')
+    const figmaStatus = q<HTMLDivElement>('[data-el="figmaStatus"]')
+    const xInput = q<HTMLInputElement>('[data-el="x"]')
+    const yInput = q<HTMLInputElement>('[data-el="y"]')
+    const scaleInput = q<HTMLInputElement>('[data-el="scale"]')
+    const opacityInput = q<HTMLInputElement>('[data-el="opacity"]')
+    const opacityVal = q<HTMLSpanElement>('[data-el="opacityVal"]')
+    const diffBtn = q<HTMLButtonElement>('[data-act="diff"]')
+    const borderBtn = q<HTMLButtonElement>('[data-act="border"]')
+    const fitBtn = q<HTMLButtonElement>('[data-act="fit"]')
+    const visibleBtn = q<HTMLButtonElement>('[data-act="visible"]')
+    const lockedBtn = q<HTMLButtonElement>('[data-act="locked"]')
+    const collapseBtn = q<HTMLButtonElement>('[data-act="collapse"]')
+    const resetBtn = q<HTMLButtonElement>('[data-el="resetBtn"]')
+    const titleEl = q<HTMLElement>('[data-el="title"]')
+    const body = q<HTMLDivElement>('[data-el="body"]')
+
+    // Restore the saved Figma token (if any) and persist edits as they happen.
+    figmaTokenInput.value = localStorage.getItem(FIGMA_TOKEN_KEY) ?? ''
+    figmaTokenInput.addEventListener('input', () => {
+        const t = figmaTokenInput.value.trim()
+        if (t) localStorage.setItem(FIGMA_TOKEN_KEY, t)
+        else localStorage.removeItem(FIGMA_TOKEN_KEY)
+    })
+
+    // Drag & drop (loading via the drop box / page-wide catcher, and dragging
+    // the overlay to reposition it) is only active when the overlay is both
+    // visible and unlocked.
+    const dragEnabled = () => state.visible && !state.locked
+
+    const syncUi = () => {
+        const active = document.activeElement
+        if (urlInput !== active) urlInput.value = state.src.startsWith('data:') ? '' : state.src
+        if (xInput !== active) xInput.value = String(state.x)
+        if (yInput !== active) yInput.value = String(state.y)
+        if (scaleInput !== active) scaleInput.value = String(state.scale)
+        if (opacityInput !== active) opacityInput.value = String(state.opacity)
+        opacityVal.textContent = `${Math.round(state.opacity * 100)}%`
+        diffBtn.style.background = state.diff ? '#FFEF46' : '#2a2d33'
+        diffBtn.style.color = state.diff ? '#1F2018' : '#F5F8FF'
+        borderBtn.style.background = state.border ? '#FFEF46' : '#2a2d33'
+        borderBtn.style.color = state.border ? '#1F2018' : '#F5F8FF'
+        // Highlight "fit" while fitted; clicking again restores the prior size.
+        fitBtn.style.background = preFit ? '#FFEF46' : '#2a2d33'
+        fitBtn.style.color = preFit ? '#1F2018' : '#F5F8FF'
+        fitBtn.title = preFit
+            ? 'Restore previous size & position'
+            : 'Scale to iframe width and center'
+        visibleBtn.textContent = state.visible ? 'hide' : 'show'
+        // Show the lock STATE (not just the action) and highlight when locked,
+        // so it's obvious why the overlay can't be dragged.
+        lockedBtn.textContent = state.locked ? '🔒 locked' : '🔓 movable'
+        lockedBtn.style.background = state.locked ? '#FFEF46' : '#2a2d33'
+        lockedBtn.style.color = state.locked ? '#1F2018' : '#F5F8FF'
+        lockedBtn.title = state.locked
+            ? 'Overlay is locked — click to allow dragging'
+            : 'Overlay is draggable — click to lock it in place'
+        // Drag & drop (the drop box + page-wide drop catcher) only makes sense
+        // while the overlay is interactive: hide it when the overlay is locked
+        // or hidden, restore it when visible and movable.
+        dropzone.style.display = dragEnabled() ? '' : 'none'
+        // Collapsed: shrink to a slim vertical tab; only the collapse button
+        // (with the label rotated vertically) stays. Expanded: normal panel.
+        body.style.display = state.collapsed ? 'none' : ''
+        resetBtn.style.display = state.collapsed ? 'none' : ''
+        titleEl.style.display = state.collapsed ? 'none' : ''
+        panel.style.width = state.collapsed ? 'auto' : '240px'
+        panel.style.padding = state.collapsed ? '6px' : '10px'
+        if (state.collapsed) {
+            collapseBtn.textContent = '▸ Visual diff'
+            collapseBtn.style.writingMode = 'vertical-rl'
+            collapseBtn.style.padding = '8px 5px'
+            collapseBtn.title = 'Expand panel'
+            // Flush against the right edge, rounded only on the left like a tab.
+            panel.style.right = '0'
+            panel.style.borderRadius = '8px 0 0 8px'
+        } else {
+            collapseBtn.textContent = '▾'
+            collapseBtn.style.writingMode = ''
+            collapseBtn.style.padding = '4px 7px'
+            collapseBtn.title = 'Collapse panel'
+            panel.style.right = '8px'
+            panel.style.borderRadius = '8px'
+        }
+        applyImg()
+        save()
+    }
+
+    // When loading a new image, default to scale 1 (real pixels) and just
+    // center it. The user can still hit "fit" to auto-scale to iframe width.
+    const resetScaleAndCenter = () => {
+        preFit = null
+        state = { ...state, scale: 1 }
+        centerXOnly()
+    }
+    // Load an image File (from the file picker or a drag&drop) as the overlay.
+    const loadFromFile = (f: File) => {
+        const reader = new FileReader()
+        reader.onload = () => {
+            state = { ...state, src: String(reader.result), visible: true }
+            syncUi()
+            resetScaleAndCenter()
+        }
+        reader.onerror = () => { figmaStatus.textContent = `file read error: ${reader.error?.message ?? 'unknown'}` }
+        reader.readAsDataURL(f)
+    }
+    fileInput.addEventListener('change', () => {
+        const f = fileInput.files?.[0]
+        if (!f) return
+        loadFromFile(f)
+    })
+    // Explicit, always-visible drop target inside the panel. The panel lives
+    // in the parent document (never under the cross-origin portal iframe), so
+    // dropping here is reliable even when window-level drag detection misses
+    // the initial dragenter over the iframe.
+    const loadFromDataTransfer = (dt: DataTransfer | null): boolean => {
+        if (!dt) return false
+        const file = Array.from(dt.files || []).find(f => f.type.startsWith('image/'))
+        if (file) { loadFromFile(file); return true }
+        const url = (
+            dt.getData('text/uri-list') ||
+            imgUrlFromHtml(dt.getData('text/html')) ||
+            dt.getData('text/plain') ||
+            ''
+        ).trim()
+        if (!url) return false
+        state = { ...state, src: url, visible: true }
+        syncUi()
+        resetScaleAndCenter()
+        return true
+    }
+    const dzOver = (e: DragEvent) => {
+        if (!dragEnabled()) return
+        e.preventDefault()
+        e.stopPropagation()
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+        dropzone.style.borderColor = '#FFEF46'
+        dropzone.style.color = '#F5F8FF'
+    }
+    const dzLeave = () => {
+        dropzone.style.borderColor = '#2a2d33'
+        dropzone.style.color = '#9aa0a6'
+    }
+    dropzone.addEventListener('dragenter', dzOver)
+    dropzone.addEventListener('dragover', dzOver)
+    dropzone.addEventListener('dragleave', dzLeave)
+    dropzone.addEventListener('drop', (e: DragEvent) => {
+        if (!dragEnabled()) return
+        e.preventDefault()
+        e.stopPropagation()
+        dzLeave()
+        loadFromDataTransfer(e.dataTransfer)
+    })
+    urlInput.addEventListener('blur', () => {
+        const v = urlInput.value.trim()
+        if (v && v !== state.src) {
+            state = { ...state, src: v }
+            syncUi()
+            resetScaleAndCenter()
+        }
+    })
+    const onNumberInput = (el: HTMLInputElement, key: 'x' | 'y' | 'scale' | 'opacity', fallback: number) => {
+        el.addEventListener('input', () => {
+            // Skip while the field is mid-edit (e.g. just `-` or empty) so we
+            // don't replace the caret content; commit on blur instead.
+            const raw = el.value
+            if (raw === '' || raw === '-' || raw === '.' || raw === '-.') return
+            const n = Number(raw)
+            if (!Number.isFinite(n)) return
+            state = { ...state, [key]: n }
+            syncUi()
+        })
+        el.addEventListener('blur', () => {
+            const n = Number(el.value)
+            state = { ...state, [key]: Number.isFinite(n) ? n : fallback }
+            syncUi()
+        })
+    }
+    onNumberInput(xInput, 'x', 0)
+    onNumberInput(yInput, 'y', 0)
+    onNumberInput(scaleInput, 'scale', 1)
+    onNumberInput(opacityInput, 'opacity', 0.5)
+
+    panel.addEventListener('click', (e) => {
+        const t = e.target as HTMLElement
+        const act = t.getAttribute('data-act')
+        if (!act) return
+        if (act === 'reset') { state = { ...DEFAULTS }; preFit = null; syncUi() }
+        else if (act === 'collapse') { state = { ...state, collapsed: !state.collapsed }; syncUi() }
+        else if (act === 'diff') { state = { ...state, diff: !state.diff }; syncUi() }
+        else if (act === 'border') { state = { ...state, border: !state.border }; syncUi() }
+        else if (act === 'fit') {
+            if (preFit) {
+                // Second click: un-fit, restoring the size/position from before.
+                const { scale, x, y } = preFit
+                preFit = null
+                state = { ...state, scale, x, y }
+                syncUi()
+            } else {
+                preFit = { scale: state.scale, x: state.x, y: state.y }
+                fitAndCenter()
+                syncUi()
+            }
+        }
+        else if (act === 'center') { centerXOnly() }
+        else if (act === 'visible') { state = { ...state, visible: !state.visible }; syncUi() }
+        else if (act === 'locked') { state = { ...state, locked: !state.locked }; syncUi() }
+        else if (act === 'fetchFigma') {
+            const url = figmaInput.value.trim()
+            if (!url) { figmaStatus.textContent = 'Paste a Figma URL with a node-id'; return }
+            const token = figmaTokenInput.value.trim()
+            figmaStatus.textContent = 'Loading…'
+
+            // With a token: call the Figma REST API straight from the browser
+            // (works on the hosted static build, where the dev proxy is absent).
+            // Without one: fall back to the dev-only `/__figma-image` proxy.
+            const loader = token
+                ? (async (): Promise<string> => {
+                    const parsed = parseFigmaUrl(url)
+                    if (!parsed) throw new Error('Expected a Figma URL with a node-id')
+                    const { fileKey, nodeId } = parsed
+                    const r = await fetch(
+                        `https://api.figma.com/v1/images/${fileKey}?ids=${encodeURIComponent(nodeId)}&format=png&scale=1`,
+                        { headers: { 'X-Figma-Token': token } },
+                    )
+                    const data = await r.json() as { images?: Record<string, string | null>; err?: string }
+                    if (!r.ok) throw new Error(data.err || `Figma API ${r.status}`)
+                    const imageUrl = data.images?.[nodeId]
+                    if (!imageUrl) throw new Error(`No image returned for node ${nodeId}`)
+                    return imageUrl
+                })
+                : (async (): Promise<string> => {
+                    const r = await fetch(`/__figma-image?url=${encodeURIComponent(url)}`)
+                    const data = await r.json() as { imageUrl?: string; error?: string }
+                    if (!r.ok || !data.imageUrl) throw new Error(data.error ?? `HTTP ${r.status}`)
+                    return data.imageUrl
+                })
+
+            loader()
+                .then(src => {
+                    state = { ...state, src }
+                    figmaStatus.textContent = 'Loaded'
+                    syncUi()
+                    resetScaleAndCenter()
+                })
+                .catch(err => { figmaStatus.textContent = err instanceof Error ? err.message : String(err) })
+        }
+    })
+
+    window.addEventListener('keydown', (e) => {
+        const tgt = e.target as HTMLElement | null
+        if (tgt && /^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName)) return
+        const step = e.shiftKey ? 10 : 1
+        if (e.key === 'ArrowLeft') state = { ...state, x: state.x - step }
+        else if (e.key === 'ArrowRight') state = { ...state, x: state.x + step }
+        else if (e.key === 'ArrowUp') state = { ...state, y: state.y - step }
+        else if (e.key === 'ArrowDown') state = { ...state, y: state.y + step }
+        else return
+        e.preventDefault()
+        syncUi()
+    })
+
+    syncUi()
+    if (state.src) centerXOnly()
+
+    // --- drag & drop -------------------------------------------------------
+    // Drop a Figma image anywhere on the page to load it as the overlay.
+    // Works with image files (from disk) and with images dragged straight
+    // out of Figma / another browser tab (which arrive as a URL).
+    //
+    // The portal lives in a (cross-origin) <iframe>, which swallows drag
+    // events while the pointer is over it. To work around that, a
+    // full-viewport catcher is shown (above the iframe) as soon as a drag
+    // carrying an image is detected, so the drop always lands on the wrapper.
+    // Visibility is driven by a timeout that refreshes on every `dragover`
+    // and clears on drop — this avoids the flaky `dragleave`/`relatedTarget`
+    // behaviour you get with cross-origin iframes.
+    const dropHint = document.createElement('div')
+    Object.assign(dropHint.style, {
+        position: 'fixed',
+        inset: '0',
+        zIndex: '2147483645',
+        display: 'none',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(12,15,20,0.55)',
+    } as CSSStyleDeclaration)
+    const dropHintInner = document.createElement('div')
+    Object.assign(dropHintInner.style, {
+        border: '3px dashed #FFEF46',
+        borderRadius: '12px',
+        padding: '24px 36px',
+        background: 'rgba(20,22,28,0.9)',
+        color: '#F5F8FF',
+        font: '600 16px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace',
+        textAlign: 'center',
+        pointerEvents: 'none',
+    } as CSSStyleDeclaration)
+    dropHintInner.textContent = 'Drop Figma image to overlay'
+    dropHint.appendChild(dropHintInner)
+    document.body.appendChild(dropHint)
+
+    let hideTimer = 0
+    const hideHint = () => { window.clearTimeout(hideTimer); dropHint.style.display = 'none' }
+    const scheduleHide = () => {
+        window.clearTimeout(hideTimer)
+        hideTimer = window.setTimeout(() => { dropHint.style.display = 'none' }, 250)
+    }
+
+    const carriesImage = (dt: DataTransfer | null) =>
+        !!dt && Array.from(dt.types || []).some(t =>
+            t === 'Files' || t === 'text/uri-list' || t === 'text/plain' || t === 'text/html')
+
+    const imgUrlFromHtml = (html: string): string => {
+        const m = html.match(/<img[^>]+src=["']([^"']+)["']/i)
+        return m ? m[1] : ''
+    }
+
+    // Show the catcher and keep the drop allowed for the whole drag. Using
+    // capture so these fire before the iframe (or anything else) can consume
+    // the event, and on every dragover so the timeout never lapses mid-drag.
+    const onDragActive = (e: DragEvent) => {
+        if (!dragEnabled()) return
+        if (!carriesImage(e.dataTransfer)) return
+        e.preventDefault()
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+        dropHint.style.display = 'flex'
+        scheduleHide()
+    }
+    window.addEventListener('dragenter', onDragActive, true)
+    window.addEventListener('dragover', onDragActive, true)
+    window.addEventListener('dragend', hideHint, true)
+
+    window.addEventListener('drop', (e: DragEvent) => {
+        if (!dragEnabled()) return
+        const dt = e.dataTransfer
+        if (!dt || !carriesImage(dt)) return
+        e.preventDefault()
+        hideHint()
+        const file = Array.from(dt.files || []).find(f => f.type.startsWith('image/'))
+        if (file) { loadFromFile(file); return }
+        const url = (
+            dt.getData('text/uri-list') ||
+            imgUrlFromHtml(dt.getData('text/html')) ||
+            dt.getData('text/plain') ||
+            ''
+        ).trim()
+        if (!url) return
+        state = { ...state, src: url, visible: true }
+        syncUi()
+        resetScaleAndCenter()
+    }, true)
+}

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -2,8 +2,9 @@
  * Dev-only visual-diff overlay for the dev-wrapper.
  *
  * Drop a Figma PNG export over the running wrapper page to pixel-compare
- * layouts. Enable by adding `?visualDiff=1` to the URL (the flag is then
- * persisted to localStorage so reloads keep it on).
+ * layouts. The overlay is always mounted; `VITE_VISUAL_DIFF` controls whether
+ * the panel starts expanded or collapsed. The loaded image, position, and
+ * settings are persisted to localStorage so reloads keep them.
  *
  * Controls:
  *   - File picker, URL field, or drag & drop to load an image (drop a PNG
@@ -14,9 +15,9 @@
  *   - `diff` toggles `mix-blend-mode: difference` (matching pixels go black)
  *   - `hide` / `lock` / `reset`
  *
- * Note: this overlays the dev-wrapper page itself, NOT the portal inside the
- * iframe. To overlay the portal, open the portal directly with `?visualDiff=1`
- * (the React mount in `src/dev/VisualDiffOverlay.tsx` handles that case).
+ * Note: this overlays the dev-wrapper page itself, NOT the portal rendered
+ * inside the iframe (the portal is served from a separate origin in the
+ * iframe, so it can't be overlaid from here).
  */
 
 type State = {

--- a/dev-wrapper/vite.config.ts
+++ b/dev-wrapper/vite.config.ts
@@ -1,12 +1,67 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 
 // Dev-only wrapper that simulates a partner site embedding the Cashback
 // Portal in an iframe. Runs on a different port from the portal itself so
 // they can run side-by-side.
-export default defineConfig({
-    server: {
-        port: 5174,
-        host: true,
-        strictPort: true,
+
+// Dev-only middleware that resolves a Figma frame URL to a rendered PNG URL
+// via the Figma REST API, so the visual-diff overlay panel can fetch an
+// image straight from a Figma link. Token is read from the FIGMA_TOKEN
+// env var on the server so it never reaches the browser.
+const figmaImageProxy = (token: string | undefined) => ({
+    name: 'figma-image-proxy',
+    configureServer(server: import('vite').ViteDevServer) {
+        server.middlewares.use('/__figma-image', async (req, res) => {
+            const send = (status: number, body: unknown) => {
+                res.statusCode = status
+                res.setHeader('Content-Type', 'application/json')
+                res.end(JSON.stringify(body))
+            }
+            try {
+                if (!token) return send(500, { error: 'FIGMA_TOKEN env var is not set' })
+
+                const url = new URL(req.url ?? '', 'http://localhost').searchParams.get('url') ?? ''
+                // Match `/file/:key` or `/design/:key` plus a `node-id` query (dashes or colons).
+                const fileMatch = url.match(/figma\.com\/(?:file|design|board|proto)\/([A-Za-z0-9]+)/)
+                const nodeMatch = url.match(/[?&]node-id=([0-9]+[-:][0-9]+)/)
+                if (!fileMatch || !nodeMatch) {
+                    return send(400, { error: 'Expected a Figma URL with a node-id query param' })
+                }
+                const fileKey = fileMatch[1]
+                const nodeId = nodeMatch[1].replace('-', ':')
+
+                const scale = new URL(req.url ?? '', 'http://localhost').searchParams.get('scale') ?? '1'
+                const figmaRes = await fetch(
+                    `https://api.figma.com/v1/images/${fileKey}?ids=${encodeURIComponent(nodeId)}&format=png&scale=${encodeURIComponent(scale)}`,
+                    { headers: { 'X-Figma-Token': token } },
+                )
+                if (!figmaRes.ok) {
+                    return send(figmaRes.status, { error: `Figma API ${figmaRes.status}: ${await figmaRes.text()}` })
+                }
+                const data = (await figmaRes.json()) as { images?: Record<string, string | null>; err?: string }
+                if (data.err) return send(502, { error: data.err })
+                const imageUrl = data.images?.[nodeId]
+                if (!imageUrl) return send(404, { error: `No image returned for node ${nodeId}` })
+                return send(200, { imageUrl, fileKey, nodeId })
+            } catch (err) {
+                return send(500, { error: err instanceof Error ? err.message : String(err) })
+            }
+        })
     },
+})
+
+export default defineConfig(({ mode }) => {
+    // Load all env vars from .env / .env.local (the empty prefix means we get
+    // non-VITE_ vars too, which we need for the server-only FIGMA_TOKEN).
+    const env = loadEnv(mode, process.cwd(), '')
+    const figmaToken = env.FIGMA_TOKEN || process.env.FIGMA_TOKEN
+
+    return {
+        plugins: [figmaImageProxy(figmaToken)],
+        server: {
+            port: 5174,
+            host: true,
+            strictPort: true,
+        },
+    }
 })


### PR DESCRIPTION
This pull request significantly improves the `dev-wrapper` developer environment for the Cashback Portal by introducing per-provider API configuration, a visual diff overlay for design comparison, and enhanced documentation and UI feedback. It also adds deployment and SEO controls. The most important changes are grouped below:

**Per-provider API configuration and UI feedback:**

* Added support for per-provider API URLs and keys via new environment variables (`VITE_PORTAL_API_<PROVIDER>`, `VITE_PORTAL_API_KEY_<PROVIDER>`). The selected wallet provider determines which API URL/key is used, with fallbacks to the default values. The active API stage is now shown read-only in the sidebar UI, updating dynamically with provider changes. [[1]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087L45-R70) [[2]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087L12-R15) [[3]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087R94-R98) [[4]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285L24-R77) [[5]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285R88) [[6]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285R101-R102) [[7]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285R261-R262) [[8]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285R307-R311) [[9]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285L411-R496) [[10]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285L429-R516) [[11]](diffhunk://#diff-79979fc09a49a886831d3dfdf0719060a2526c1ccfdb448befa3ac2ff2ad0a4dR40-R54)

**Visual diff overlay:**

* Introduced a visual diff overlay tool for pixel-comparing the running page against Figma designs or images. The overlay is always available (controlled by `VITE_VISUAL_DIFF`), supports loading images by URL, file, or Figma API, and persists its state in `localStorage`. Documentation for its usage and controls was added. [[1]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285R11-R22) [[2]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087R112-R155)

**User interface enhancements:**

* Added a "Log out" button (hidden on localhost) to clear cached CloudFront basic-auth credentials, ensuring users can force a credentials prompt when needed. [[1]](diffhunk://#diff-224fb9a0c6d31054c9f9d752ebe9ac05aa5bad999aa9a198c7330c6f73221659R23-R34) [[2]](diffhunk://#diff-98f13e3fd7e77780cfa2de2e2ae9eccca5cf0c44da746a1ac825496b8f1c7285R127-R149) [[3]](diffhunk://#diff-79979fc09a49a886831d3dfdf0719060a2526c1ccfdb448befa3ac2ff2ad0a4dR79-R105)
* Improved sidebar UI to display the active API stage and clarified the wallet provider selection's effect on API config. [[1]](diffhunk://#diff-224fb9a0c6d31054c9f9d752ebe9ac05aa5bad999aa9a198c7330c6f73221659R23-R34) [[2]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087R94-R98) [[3]](diffhunk://#diff-79979fc09a49a886831d3dfdf0719060a2526c1ccfdb448befa3ac2ff2ad0a4dR40-R54)

**Documentation and environment management:**

* Updated the README to document per-provider API config, the visual diff overlay, and all new environment variables. [[1]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087L12-R15) [[2]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087L45-R70) [[3]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087R94-R98) [[4]](diffhunk://#diff-e9998f8d4ced5d338860b5d701c0570d252e3fc9ee34bfb4d736eb420694c087R112-R155)
* Updated `.gitignore` to exclude all `.env` files except `.env.example`, and added a `robots.txt` and meta tags to prevent indexing of the dev wrapper. [[1]](diffhunk://#diff-53d004b8cf8eb1c75f02834909971dbd96a78db0d52d1ddc7516343ede68916dR1-R4) [[2]](diffhunk://#diff-f77e6126d50e460d65ce108cc4a02f49346686a4b63a41b98532580705d659a5R1-R2) [[3]](diffhunk://#diff-224fb9a0c6d31054c9f9d752ebe9ac05aa5bad999aa9a198c7330c6f73221659R6-R8)

**Deployment improvements:**

* Added a `deploy` script to `package.json` for streamlined S3 and CloudFront deployment, with proper cache control for `index.html` and assets.

These updates provide a more flexible, informative, and developer-friendly environment for testing and iterating on the Cashback Portal.