### PR TITLE
dev-wrapper: add one-command deploy for portal + wrapper

### DIFF
--- a/dev-wrapper/.env.deploy.example
+++ b/dev-wrapper/.env.deploy.example
@@ -1,8 +1,8 @@
 # Deploy targets for `yarn deploy` (see deploy.sh).
 # Copy this file to `.env.deploy` and fill in the real values.
 # These are infra identifiers (S3 bucket + CloudFront distribution id), not
-# credentials — AWS access still requires your own IAM credentials. They are
-# get the values from the team channel.
+# credentials — AWS access still requires your own IAM credentials. Get the
+# values from the team channel.
 
 # Portal app (the iframe content, built from the repo root).
 PORTAL_BUCKET=replace-me

--- a/dev-wrapper/.env.deploy.example
+++ b/dev-wrapper/.env.deploy.example
@@ -1,0 +1,13 @@
+# Deploy targets for `yarn deploy` (see deploy.sh).
+# Copy this file to `.env.deploy` and fill in the real values.
+# These are infra identifiers (S3 bucket + CloudFront distribution id), not
+# credentials — AWS access still requires your own IAM credentials. They are
+# get the values from the team channel.
+
+# Portal app (the iframe content, built from the repo root).
+PORTAL_BUCKET=replace-me
+PORTAL_DIST=replace-me
+
+# Dev wrapper shell (built from dev-wrapper/).
+WRAPPER_BUCKET=replace-me
+WRAPPER_DIST=replace-me

--- a/dev-wrapper/.gitignore
+++ b/dev-wrapper/.gitignore
@@ -2,3 +2,4 @@
 .env
 .env.*
 !.env.example
+!.env.deploy.example

--- a/dev-wrapper/deploy.sh
+++ b/dev-wrapper/deploy.sh
@@ -18,6 +18,13 @@ if [[ ! -f .env.deploy ]]; then
   exit 1
 fi
 
+# Reject anything except blank lines, comments, or simple KEY=VALUE assignments.
+# This avoids accidentally executing shell code when sourcing the deploy config.
+if grep -Eqv '^\s*(#.*)?$|^[A-Za-z_][A-Za-z0-9_]*=([A-Za-z0-9._-]+|"[A-Za-z0-9._-]+")$' .env.deploy; then
+  echo "error: .env.deploy must contain only KEY=VALUE lines (no shell code)." >&2
+  exit 1
+fi
+
 set -a
 # shellcheck disable=SC1091
 . ./.env.deploy

--- a/dev-wrapper/deploy.sh
+++ b/dev-wrapper/deploy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Deploy the portal (iframe content) and/or the dev-wrapper shell.
+#
+# Usage:
+#   ./deploy.sh            # deploy both portal and wrapper
+#   ./deploy.sh portal     # deploy the portal app only
+#   ./deploy.sh wrapper    # deploy the dev-wrapper shell only
+#
+# Deploy targets (S3 bucket + CloudFront distribution id) are read from
+# .env.deploy, which is gitignored. See .env.deploy.example for the template.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ ! -f .env.deploy ]]; then
+  echo "error: dev-wrapper/.env.deploy not found." >&2
+  echo "       Copy .env.deploy.example to .env.deploy and fill in the values." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+. ./.env.deploy
+set +a
+
+deploy_target() {
+  local dist_dir="$1" bucket="$2" distribution="$3"
+  aws s3 sync "$dist_dir" "s3://$bucket" --delete \
+    --exclude index.html \
+    --cache-control "public,max-age=31536000,immutable"
+  aws s3 cp "$dist_dir/index.html" "s3://$bucket/index.html" \
+    --cache-control "no-cache" \
+    --content-type "text/html; charset=utf-8"
+  aws cloudfront create-invalidation --distribution-id "$distribution" --paths "/*"
+}
+
+deploy_portal() {
+  : "${PORTAL_BUCKET:?set PORTAL_BUCKET in .env.deploy}"
+  : "${PORTAL_DIST:?set PORTAL_DIST in .env.deploy}"
+  echo "==> Building and deploying portal -> $PORTAL_BUCKET"
+  yarn --cwd .. build
+  deploy_target ../dist "$PORTAL_BUCKET" "$PORTAL_DIST"
+}
+
+deploy_wrapper() {
+  : "${WRAPPER_BUCKET:?set WRAPPER_BUCKET in .env.deploy}"
+  : "${WRAPPER_DIST:?set WRAPPER_DIST in .env.deploy}"
+  echo "==> Building and deploying wrapper -> $WRAPPER_BUCKET"
+  yarn build
+  deploy_target dist "$WRAPPER_BUCKET" "$WRAPPER_DIST"
+}
+
+case "${1:-all}" in
+  portal) deploy_portal ;;
+  wrapper) deploy_wrapper ;;
+  all) deploy_portal; deploy_wrapper ;;
+  *) echo "usage: $0 [portal|wrapper|all]" >&2; exit 2 ;;
+esac
+
+echo "Done."

--- a/dev-wrapper/package.json
+++ b/dev-wrapper/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "deploy": "yarn build && aws s3 sync dist s3://portal-viewer.bringweb3.io --delete --exclude index.html --cache-control \"public,max-age=31536000,immutable\" && aws s3 cp dist/index.html s3://portal-viewer.bringweb3.io/index.html --cache-control \"no-cache\" --content-type \"text/html; charset=utf-8\" && aws cloudfront create-invalidation --distribution-id E1LQKQMDXNNDKB --paths \"/*\""
+    "deploy": "bash deploy.sh",
+    "deploy:portal": "bash deploy.sh portal",
+    "deploy:wrapper": "bash deploy.sh wrapper"
   },
   "devDependencies": {
     "typescript": "^5.5.4",


### PR DESCRIPTION
## What

Adds a single-command deploy for the dev preview at `portal-viewer.bringweb3.io`, covering **both** pieces that sit behind it:

- the **portal** app (the iframe content, built from the repo root) → its S3 bucket
- the **dev-wrapper** shell → its S3 bucket

Previously only the wrapper had a deploy script, so portal (`src/`) changes never reached the preview unless deployed manually.

## Changes

- **`dev-wrapper/deploy.sh`** (new): builds and ships the portal and/or wrapper to S3 with CloudFront invalidations. Accepts `portal`, `wrapper`, or no arg (both).
- **`dev-wrapper/package.json`**: `deploy` / `deploy:portal` / `deploy:wrapper` now wrap `deploy.sh`.
- Deploy targets (S3 bucket + CloudFront distribution ids) are read from a **gitignored `.env.deploy`** instead of being hardcoded in this public repo.
- **`dev-wrapper/.env.deploy.example`** (new): tracked template documenting the required keys.
- **`dev-wrapper/.gitignore`**: keeps `.env.deploy.example` tracked while ignoring `.env.deploy`.

## Usage

```bash
cd dev-wrapper
yarn deploy                          # portal + wrapper
```

## Notes

- No infra identifiers or secrets are committed — only placeholders in `.env.deploy.example`.
- Requires the AWS CLI + credentials already used for prior deploys.
