### PR TITLE
feat(dev-wrapper): expand visual-diff overlay — paste, grid, guides, …

### DIFF
--- a/dev-wrapper/.gitignore
+++ b/dev-wrapper/.gitignore
@@ -3,3 +3,6 @@
 .env.*
 !.env.example
 !.env.deploy.example
+
+# TypeScript incremental build cache
+*.tsbuildinfo

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -794,10 +794,12 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         } catch { /* iframe not ready / bad src */ }
     }
 
-    // Our own overlay chrome shouldn't be pickable.
+    // Our own overlay chrome shouldn't be pickable. (A locked *element* stays
+    // pickable so clicking it again unlocks it — only the lock boxes are
+    // chrome.)
     const isOwnUi = (el: Element): boolean =>
         el === hoverBox || el === panel || panel.contains(el) || el === img || el === grid ||
-        wrapperLocks.has(el) || [...wrapperLocks.values()].some(b => b === el) ||
+        [...wrapperLocks.values()].some(b => b === el) ||
         [...guideEls.values()].some(g => g === el)
 
     const describeEl = (el: Element): string => {

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -13,12 +13,21 @@
  *   - Drag the overlay image to position it (arrow keys nudge 1px,
  *     shift+arrows 10px)
  *   - `diff` toggles `mix-blend-mode: difference` (matching pixels go black)
+ *   - `invert` toggles `filter: invert(1)` (flip the overlay's colors)
+ *   - `grid` toggles a full-page pixel ruler grid (adjustable cell size/color)
+ *   - `+ vert` / `+ horz` drop draggable guide lines (double-click one to
+ *     remove it, `clear` removes all); each shows a live px readout
  *   - `hide` / `lock` / `reset`
  *
  * Note: this overlays the dev-wrapper page itself, NOT the portal rendered
  * inside the iframe (the portal is served from a separate origin in the
  * iframe, so it can't be overlaid from here).
  */
+
+// A draggable ruler guide. `axis: 'x'` is a vertical line movable horizontally
+// (pos = its left/x coordinate); `axis: 'y'` is a horizontal line movable
+// vertically (pos = its top/y coordinate). Coordinates are viewport CSS px.
+type Guide = { id: string; axis: 'x' | 'y'; pos: number }
 
 type State = {
     src: string
@@ -27,10 +36,15 @@ type State = {
     scale: number
     opacity: number
     diff: boolean
+    invert: boolean
     visible: boolean
     locked: boolean
     collapsed: boolean
     border: boolean
+    grid: boolean
+    gridSize: number
+    gridColor: string
+    guides: Guide[]
 }
 
 const STORAGE_KEY = 'bring.visualDiff.wrapper.v1'
@@ -55,10 +69,15 @@ const DEFAULTS: State = {
     scale: 1,
     opacity: 0.5,
     diff: false,
+    invert: false,
     visible: true,
     locked: false,
     collapsed: false,
     border: false,
+    grid: false,
+    gridSize: 8,
+    gridColor: '#FF2D9B',
+    guides: [],
 }
 
 const loadState = (): State => {
@@ -144,6 +163,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         img.style.transform = `scale(${state.scale})`
         img.style.opacity = String(state.opacity)
         img.style.mixBlendMode = state.diff ? 'difference' : 'normal'
+        img.style.filter = state.invert ? 'invert(1)' : 'none'
         // Outline (not border) so toggling it never shifts the image's size/pos.
         img.style.outline = state.border ? '2px solid #FF2D9B' : 'none'
         img.style.outlineOffset = state.border ? '-1px' : '0'
@@ -180,6 +200,173 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         img.addEventListener('pointercancel', up)
     })
 
+    // --- pixel grid --------------------------------------------------------
+    // Full-viewport ruler grid for eyeballing pixel alignment. Minor lines
+    // every `gridSize` px, with a stronger major line every 8th cell. Sits
+    // above the overlay image but below the panel, and never eats pointer
+    // events so dragging the image/page still works through it.
+    const grid = document.createElement('div')
+    Object.assign(grid.style, {
+        position: 'fixed',
+        inset: '0',
+        zIndex: '2147483646',
+        pointerEvents: 'none',
+        display: 'none',
+    } as CSSStyleDeclaration)
+    document.body.appendChild(grid)
+
+    const applyGrid = () => {
+        if (!state.grid) {
+            grid.style.display = 'none'
+            return
+        }
+        const g = Math.max(1, state.gridSize)
+        const major = g * 8
+        // Both tiers share the chosen hue; alpha is appended as #RRGGBBAA
+        // (73 ≈ 0.45 for major lines, 24 ≈ 0.14 for minor lines). Fall back to
+        // the default pink if the stored value isn't a 6-digit hex.
+        const hex = /^#[0-9a-fA-F]{6}$/.test(state.gridColor) ? state.gridColor : '#FF2D9B'
+        grid.style.display = ''
+        grid.style.backgroundImage = [
+            `linear-gradient(to right, ${hex}73 1px, transparent 1px)`,
+            `linear-gradient(to bottom, ${hex}73 1px, transparent 1px)`,
+            `linear-gradient(to right, ${hex}24 1px, transparent 1px)`,
+            `linear-gradient(to bottom, ${hex}24 1px, transparent 1px)`,
+        ].join(',')
+        grid.style.backgroundSize = `${major}px ${major}px, ${major}px ${major}px, ${g}px ${g}px, ${g}px ${g}px`
+    }
+
+    // --- guide lines -------------------------------------------------------
+    // Draggable full-screen ruler guides (like a design tool). Each guide is a
+    // 9px-wide hit strip with a 1px line drawn down its center; it's dragged
+    // along its perpendicular axis and shows a live px readout. Double-click a
+    // guide to remove it. Guides live in STATE so they persist across reloads.
+    const GUIDE_COLOR = '#00E5FF'
+    const guideEls = new Map<string, HTMLDivElement>()
+    // Monotonic id source. Seed past any persisted ids so a reload + add never
+    // reuses an existing id.
+    let guideSeq = state.guides.reduce((m, g) => {
+        const n = Number(g.id.replace(/^g/, ''))
+        return Number.isFinite(n) ? Math.max(m, n + 1) : m
+    }, 1)
+    // The guide the pointer is currently hovering, so the Delete/Backspace key
+    // knows which one to remove.
+    let hoveredGuideId: string | null = null
+
+    const removeGuide = (id: string) => {
+        state = { ...state, guides: state.guides.filter(g => g.id !== id) }
+        if (hoveredGuideId === id) hoveredGuideId = null
+        renderGuides()
+        save()
+    }
+
+    const positionGuide = (id: string) => {
+        const el = guideEls.get(id)
+        const guide = state.guides.find(g => g.id === id)
+        if (!el || !guide) return
+        const vertical = guide.axis === 'x'
+        if (vertical) {
+            Object.assign(el.style, { left: `${guide.pos - 4}px`, top: '0', bottom: '0', right: '', width: '9px', height: '' })
+        } else {
+            Object.assign(el.style, { top: `${guide.pos - 4}px`, left: '0', right: '0', bottom: '', height: '9px', width: '' })
+        }
+        const label = el.firstElementChild as HTMLElement | null
+        if (label) label.textContent = String(guide.pos)
+    }
+
+    const makeGuideEl = (guide: Guide): HTMLDivElement => {
+        const el = document.createElement('div')
+        const vertical = guide.axis === 'x'
+        Object.assign(el.style, {
+            position: 'fixed',
+            zIndex: '2147483646',
+            background: vertical
+                ? `linear-gradient(to right, transparent 4px, ${GUIDE_COLOR} 4px, ${GUIDE_COLOR} 5px, transparent 5px)`
+                : `linear-gradient(to bottom, transparent 4px, ${GUIDE_COLOR} 4px, ${GUIDE_COLOR} 5px, transparent 5px)`,
+            cursor: vertical ? 'ew-resize' : 'ns-resize',
+            touchAction: 'none',
+        } as CSSStyleDeclaration)
+        el.title = 'Drag to move · double-click or Delete to remove'
+
+        el.addEventListener('pointerenter', () => { hoveredGuideId = guide.id })
+        el.addEventListener('pointerleave', () => { if (hoveredGuideId === guide.id) hoveredGuideId = null })
+
+        const label = document.createElement('span')
+        Object.assign(label.style, {
+            position: 'absolute',
+            background: GUIDE_COLOR,
+            color: '#04222a',
+            font: '10px/1 ui-monospace, SFMono-Regular, Menlo, monospace',
+            padding: '1px 3px',
+            borderRadius: '3px',
+            pointerEvents: 'none',
+            whiteSpace: 'nowrap',
+        } as CSSStyleDeclaration)
+        // Pin the readout to the start of the line, just off the line itself.
+        label.style[vertical ? 'top' : 'left'] = '2px'
+        label.style[vertical ? 'left' : 'top'] = '6px'
+        el.appendChild(label)
+
+        el.addEventListener('pointerdown', (e: PointerEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+            el.setPointerCapture(e.pointerId)
+            const start = vertical ? e.clientX : e.clientY
+            const cur = state.guides.find(g => g.id === guide.id)
+            const base = cur ? cur.pos : guide.pos
+            const move = (ev: PointerEvent) => {
+                const pos = Math.round(base + ((vertical ? ev.clientX : ev.clientY) - start))
+                state = { ...state, guides: state.guides.map(g => g.id === guide.id ? { ...g, pos } : g) }
+                positionGuide(guide.id)
+            }
+            const up = (ev: PointerEvent) => {
+                el.removeEventListener('pointermove', move)
+                el.removeEventListener('pointerup', up)
+                el.removeEventListener('pointercancel', up)
+                try { el.releasePointerCapture(ev.pointerId) } catch { /* already released */ }
+                save()
+            }
+            el.addEventListener('pointermove', move)
+            el.addEventListener('pointerup', up)
+            el.addEventListener('pointercancel', up)
+        })
+
+        el.addEventListener('dblclick', (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            removeGuide(guide.id)
+        })
+
+        return el
+    }
+
+    // Reconcile guide DOM elements to state.guides (add new, drop removed,
+    // reposition the rest). Cheap enough to run on every state change.
+    const renderGuides = () => {
+        const ids = new Set(state.guides.map(g => g.id))
+        for (const [id, el] of guideEls) {
+            if (!ids.has(id)) { el.remove(); guideEls.delete(id) }
+        }
+        for (const guide of state.guides) {
+            if (!guideEls.has(guide.id)) {
+                const el = makeGuideEl(guide)
+                guideEls.set(guide.id, el)
+                document.body.appendChild(el)
+            }
+            positionGuide(guide.id)
+        }
+    }
+
+    const addGuide = (axis: 'x' | 'y') => {
+        const id = `g${guideSeq++}`
+        const pos = axis === 'x'
+            ? Math.round(window.innerWidth / 2)
+            : Math.round(window.innerHeight / 2)
+        state = { ...state, guides: [...state.guides, { id, axis, pos }] }
+        renderGuides()
+        save()
+    }
+
     // --- control panel -----------------------------------------------------
     const panel = document.createElement('div')
     Object.assign(panel.style, {
@@ -206,6 +393,32 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         #bring-visual-diff-panel button { transition: filter 0.12s, transform 0.05s; }
         #bring-visual-diff-panel button:hover { filter: brightness(1.25); }
         #bring-visual-diff-panel button:active { transform: translateY(1px); }
+        #bring-visual-diff-panel input[type="text"],
+        #bring-visual-diff-panel input[type="password"],
+        #bring-visual-diff-panel input[type="number"] {
+            transition: border-color 0.12s, box-shadow 0.12s, background 0.12s;
+            outline: none;
+        }
+        #bring-visual-diff-panel input[type="text"]:focus:not([data-el="url"]),
+        #bring-visual-diff-panel input[type="password"]:focus,
+        #bring-visual-diff-panel input[type="number"]:focus {
+            border-color: #FFEF46;
+            box-shadow: 0 0 0 2px rgba(255,239,70,0.18);
+            background: #11151c;
+        }
+        #bring-visual-diff-panel input::placeholder { color: #5b6068; }
+        /* The URL field is a styled wrapper around a borderless input, so the
+           focus ring lives on the wrapper via :focus-within. */
+        #bring-visual-diff-panel [data-el="urlField"] {
+            transition: border-color 0.12s, box-shadow 0.12s, background 0.12s;
+        }
+        #bring-visual-diff-panel [data-el="urlField"]:focus-within {
+            border-color: #FFEF46;
+            box-shadow: 0 0 0 2px rgba(255,239,70,0.18);
+            background: #11151c;
+        }
+        #bring-visual-diff-panel [data-act="clearUrl"] { opacity: 0.6; }
+        #bring-visual-diff-panel [data-act="clearUrl"]:hover { opacity: 1; }
     `
     document.head.appendChild(styleTag)
 
@@ -226,11 +439,18 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             <input type="password" data-el="figmaToken" placeholder="Figma token (stored in this browser only)" autocomplete="off" style="flex:1;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
         </div>
         <div data-el="figmaStatus" style="margin-top:4px;color:#9aa0a6;font-size:11px;min-height:14px"></div>
-        <div style="margin-top:6px"><input type="file" data-el="file" accept="image/png,image/jpeg,image/webp" style="font:inherit;color:#9aa0a6"></div>
-        <div data-el="dropzone" style="margin-top:6px;border:2px dashed #2a2d33;border-radius:6px;padding:10px;text-align:center;color:#9aa0a6;cursor:copy;font-size:11px">Drop image / Figma asset here</div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <input type="file" data-el="file" accept="image/png,image/jpeg,image/webp" style="flex:1;min-width:0;font:inherit;color:#9aa0a6">
+            <button data-act="paste" title="Paste an image from the clipboard (or press Ctrl/⌘+V anywhere)" style="flex:0 0 auto;background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">paste</button>
+        </div>
+        <div data-el="dropzone" style="margin-top:6px;border:2px dashed #2a2d33;border-radius:6px;padding:10px;text-align:center;color:#9aa0a6;cursor:copy;font-size:11px">Drop image / Figma asset here · or paste (Ctrl/⌘+V)</div>
         <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
             <span style="width:56px;color:#9aa0a6">URL</span>
-            <input type="text" data-el="url" placeholder="https://… or data:…" style="width:160px;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+            <div data-el="urlField" style="flex:1;min-width:0;display:flex;align-items:center;gap:4px;background:#0e1116;border:1px solid #2a2d33;border-radius:6px;padding:0 4px 0 7px">
+                <span style="color:#66686E;flex:0 0 auto;line-height:1" aria-hidden="true">🔗</span>
+                <input type="text" data-el="url" placeholder="https://… or data:…" style="flex:1;min-width:0;background:transparent;color:#F5F8FF;border:0;padding:5px 0;font:inherit;outline:none;text-overflow:ellipsis">
+                <button data-act="clearUrl" title="Clear URL" style="flex:0 0 auto;background:transparent;color:#9aa0a6;border:0;cursor:pointer;font:inherit;padding:2px 3px;line-height:1">✕</button>
+            </div>
         </div>
         <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
             <span style="width:56px;color:#9aa0a6">X / Y</span>
@@ -248,11 +468,34 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         </div>
         <div style="display:flex;align-items:center;gap:4px;margin-top:6px;flex-wrap:wrap">
             <button data-act="diff" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">diff</button>
+            <button data-act="invert" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Invert the overlay image's colors">invert</button>
             <button data-act="border" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Outline the overlay image so its bounds are visible">border</button>
             <button data-act="fit" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Scale to iframe width and center">fit</button>
             <button data-act="center" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Center horizontally (keep scale)">center</button>
             <button data-act="visible" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">hide</button>
             <button data-act="locked" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">lock</button>
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">Grid</span>
+            <button data-act="grid" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit" title="Toggle a pixel ruler grid over the page">grid</button>
+            <input type="number" min="1" step="1" data-el="gridSize" title="Minor cell size in px (major line every 8th)" style="width:64px;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+            <span style="color:#66686E;font-size:11px">px</span>
+            <input type="color" data-el="gridColor" title="Grid line color" style="width:28px;height:24px;padding:0;background:#0e1116;border:1px solid #2a2d33;border-radius:4px;cursor:pointer">
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">Guides</span>
+            <button data-act="addGuideV" title="Add a vertical guide (drag it horizontally)" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">+ vert</button>
+            <button data-act="addGuideH" title="Add a horizontal guide (drag it vertically)" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">+ horz</button>
+            <button data-act="clearGuides" title="Remove all guides" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">clear</button>
+        </div>
+        <div data-el="inspectRow">
+            <div style="display:flex;align-items:center;gap:4px;margin-top:6px;flex-wrap:wrap">
+                <span style="width:56px;color:#9aa0a6">Inspect</span>
+                <button data-act="pick" title="Highlight elements under the cursor (works inside the portal iframe too); click to lock — Esc to stop / clear" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">pick</button>
+                <button data-act="alignPick" title="Move the overlay image's top-left onto the last picked element (keeps scale)" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">align</button>
+                <button data-act="fitPick" title="Scale the overlay to the picked element's width, then align to it" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">fit→pick</button>
+            </div>
+            <div data-el="pickInfo" style="margin-top:4px;color:#9aa0a6;font-size:11px;min-height:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis"></div>
         </div>
         <div style="margin-top:6px;color:#66686E;font-size:11px">arrows = 1px · shift+arrows = 10px</div>
         </div>
@@ -271,7 +514,20 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     const opacityInput = q<HTMLInputElement>('[data-el="opacity"]')
     const opacityVal = q<HTMLSpanElement>('[data-el="opacityVal"]')
     const diffBtn = q<HTMLButtonElement>('[data-act="diff"]')
+    const invertBtn = q<HTMLButtonElement>('[data-act="invert"]')
     const borderBtn = q<HTMLButtonElement>('[data-act="border"]')
+    const gridBtn = q<HTMLButtonElement>('[data-act="grid"]')
+    const gridSizeInput = q<HTMLInputElement>('[data-el="gridSize"]')
+    const gridColorInput = q<HTMLInputElement>('[data-el="gridColor"]')
+    const pickBtn = q<HTMLButtonElement>('[data-act="pick"]')
+    const pickInfo = q<HTMLElement>('[data-el="pickInfo"]')
+    const inspectRow = q<HTMLDivElement>('[data-el="inspectRow"]')
+    // The element inspector only works locally: it needs the portal-side picker
+    // running inside the iframe, which is mounted only in DEV_MODE on the local
+    // portal. On the hosted wrapper the iframe loads a prod portal without it,
+    // so hide the row entirely rather than offer a control that can't work.
+    const isLocalHost = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]'].includes(location.hostname)
+    if (!isLocalHost) inspectRow.style.display = 'none'
     const fitBtn = q<HTMLButtonElement>('[data-act="fit"]')
     const visibleBtn = q<HTMLButtonElement>('[data-act="visible"]')
     const lockedBtn = q<HTMLButtonElement>('[data-act="locked"]')
@@ -303,8 +559,14 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         opacityVal.textContent = `${Math.round(state.opacity * 100)}%`
         diffBtn.style.background = state.diff ? '#FFEF46' : '#2a2d33'
         diffBtn.style.color = state.diff ? '#1F2018' : '#F5F8FF'
+        invertBtn.style.background = state.invert ? '#FFEF46' : '#2a2d33'
+        invertBtn.style.color = state.invert ? '#1F2018' : '#F5F8FF'
         borderBtn.style.background = state.border ? '#FFEF46' : '#2a2d33'
         borderBtn.style.color = state.border ? '#1F2018' : '#F5F8FF'
+        gridBtn.style.background = state.grid ? '#FFEF46' : '#2a2d33'
+        gridBtn.style.color = state.grid ? '#1F2018' : '#F5F8FF'
+        if (gridSizeInput !== document.activeElement) gridSizeInput.value = String(state.gridSize)
+        if (gridColorInput.value.toLowerCase() !== state.gridColor.toLowerCase()) gridColorInput.value = state.gridColor
         // Highlight "fit" while fitted; clicking again restores the prior size.
         fitBtn.style.background = preFit ? '#FFEF46' : '#2a2d33'
         fitBtn.style.color = preFit ? '#1F2018' : '#F5F8FF'
@@ -348,6 +610,8 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             panel.style.borderRadius = '8px'
         }
         applyImg()
+        applyGrid()
+        renderGuides()
         save()
     }
 
@@ -394,6 +658,39 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         resetScaleAndCenter()
         return true
     }
+    // Pull an image off the clipboard via the async Clipboard API (used by the
+    // "paste" button). The Ctrl+V `paste` event path below is preferred when
+    // available; this is the click fallback and needs clipboard-read permission.
+    const pasteFromClipboard = async () => {
+        if (!navigator.clipboard?.read) {
+            figmaStatus.textContent = 'Clipboard API unavailable — press Ctrl+V instead'
+            return
+        }
+        try {
+            const items = await navigator.clipboard.read()
+            for (const item of items) {
+                const type = item.types.find(t => t.startsWith('image/'))
+                if (type) {
+                    const blob = await item.getType(type)
+                    loadFromFile(new File([blob], 'pasted-image', { type }))
+                    figmaStatus.textContent = 'Pasted from clipboard'
+                    return
+                }
+            }
+            const text = (await navigator.clipboard.readText().catch(() => '')).trim()
+            if (/^(https?:|data:)/i.test(text)) {
+                state = { ...state, src: text, visible: true }
+                syncUi()
+                resetScaleAndCenter()
+                figmaStatus.textContent = 'Pasted image URL'
+                return
+            }
+            figmaStatus.textContent = 'Clipboard has no image'
+        } catch (err) {
+            figmaStatus.textContent = `Paste failed: ${err instanceof Error ? err.message : String(err)} (try Ctrl+V)`
+        }
+    }
+
     const dzOver = (e: DragEvent) => {
         if (!dragEnabled()) return
         e.preventDefault()
@@ -424,7 +721,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             resetScaleAndCenter()
         }
     })
-    const onNumberInput = (el: HTMLInputElement, key: 'x' | 'y' | 'scale' | 'opacity', fallback: number) => {
+    const onNumberInput = (el: HTMLInputElement, key: 'x' | 'y' | 'scale' | 'opacity' | 'gridSize', fallback: number) => {
         el.addEventListener('input', () => {
             // Skip while the field is mid-edit (e.g. just `-` or empty) so we
             // don't replace the caret content; commit on blur instead.
@@ -445,15 +742,243 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     onNumberInput(yInput, 'y', 0)
     onNumberInput(scaleInput, 'scale', 1)
     onNumberInput(opacityInput, 'opacity', 0.5)
+    onNumberInput(gridSizeInput, 'gridSize', 8)
+    gridColorInput.addEventListener('input', () => {
+        state = { ...state, gridColor: gridColorInput.value }
+        syncUi()
+    })
+
+    // --- element inspector (pick mode) -------------------------------------
+    // Highlights the element under the cursor and shows `tag · W×H`. Clicking an
+    // element LOCKS it: a persistent magenta box that stays put even after you
+    // exit pick mode or click elsewhere (click a locked element again to
+    // unlock; Esc clears all locks when not picking).
+    //
+    // On the wrapper page we read the DOM directly; inside the (cross-origin)
+    // portal iframe we can't, so the portal-side picker
+    // (src/utils/devElementPicker) draws its own hover/locked boxes there and
+    // reports geometry + lock count back over postMessage.
+    const PICK_TAG = 'bringweb3-devpick'
+    const HOVER_COLOR = '#00E5FF'
+    const LOCK_COLOR = '#FF2D9B'
+    let pickActive = false
+    let portalLockCount = 0
+    // The most recently picked element, used as the target for "align". Wrapper
+    // picks keep the element (recomputed live); portal picks keep the reported
+    // iframe-local rect (re-offset by the iframe's live position at align time).
+    type PickTarget =
+        | { kind: 'wrapper'; el: Element }
+        | { kind: 'portal'; rect: { x: number; y: number; width: number; height: number } }
+    let lastPick: PickTarget | null = null
+
+    const mkBox = (color: string, alpha: string) => {
+        const b = document.createElement('div')
+        Object.assign(b.style, {
+            position: 'fixed', zIndex: '2147483646', pointerEvents: 'none',
+            border: `1px solid ${color}`, background: alpha, boxSizing: 'border-box', display: 'none',
+        } as CSSStyleDeclaration)
+        document.body.appendChild(b)
+        return b
+    }
+    // Single hover box (follows the cursor) + a persistent box per locked
+    // wrapper-page element.
+    const hoverBox = mkBox(HOVER_COLOR, 'rgba(0,229,255,0.12)')
+    const wrapperLocks = new Map<Element, HTMLDivElement>()
+
+    const portalFrame = () => document.getElementById('portal') as HTMLIFrameElement | null
+    const postToPortal = (data: Record<string, unknown>) => {
+        const frame = portalFrame()
+        if (!frame?.contentWindow || !frame.src) return
+        try {
+            frame.contentWindow.postMessage({ ...data, to: PICK_TAG }, new URL(frame.src).origin)
+        } catch { /* iframe not ready / bad src */ }
+    }
+
+    // Our own overlay chrome shouldn't be pickable.
+    const isOwnUi = (el: Element): boolean =>
+        el === hoverBox || el === panel || panel.contains(el) || el === img || el === grid ||
+        wrapperLocks.has(el) || [...wrapperLocks.values()].some(b => b === el) ||
+        [...guideEls.values()].some(g => g === el)
+
+    const describeEl = (el: Element): string => {
+        const r = el.getBoundingClientRect()
+        const id = (el as HTMLElement).id ? `#${(el as HTMLElement).id}` : ''
+        return `${el.tagName.toLowerCase()}${id} · ${Math.round(r.width)}×${Math.round(r.height)}`
+    }
+    const placeBox = (box: HTMLDivElement, el: Element) => {
+        const r = el.getBoundingClientRect()
+        Object.assign(box.style, {
+            display: '', left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px`,
+        })
+    }
+
+    const totalLocks = () => wrapperLocks.size + portalLockCount
+    const updatePickButton = () => {
+        const n = totalLocks()
+        if (pickActive) {
+            pickBtn.textContent = 'picking… (Esc)'
+            pickBtn.style.background = '#FFEF46'; pickBtn.style.color = '#1F2018'
+        } else if (n > 0) {
+            pickBtn.textContent = `picked ${n} (Esc clears)`
+            pickBtn.style.background = LOCK_COLOR; pickBtn.style.color = '#1F2018'
+        } else {
+            pickBtn.textContent = 'pick'
+            pickBtn.style.background = '#2a2d33'; pickBtn.style.color = '#F5F8FF'
+        }
+    }
+
+    // Keep locked boxes pinned to their elements as the page scrolls/resizes.
+    let reposAttached = false
+    const repositionLocks = () => {
+        for (const [el, box] of wrapperLocks) {
+            if (!el.isConnected) { box.remove(); wrapperLocks.delete(el); continue }
+            placeBox(box, el)
+        }
+        if (wrapperLocks.size === 0) detachReposition()
+    }
+    const attachReposition = () => {
+        if (reposAttached) return
+        reposAttached = true
+        window.addEventListener('scroll', repositionLocks, true)
+        window.addEventListener('resize', repositionLocks)
+    }
+    function detachReposition() {
+        if (!reposAttached) return
+        reposAttached = false
+        window.removeEventListener('scroll', repositionLocks, true)
+        window.removeEventListener('resize', repositionLocks)
+    }
+
+    const toggleWrapperLock = (el: Element) => {
+        const existing = wrapperLocks.get(el)
+        if (existing) {
+            existing.remove(); wrapperLocks.delete(el)
+            if (wrapperLocks.size === 0) detachReposition()
+            if (lastPick?.kind === 'wrapper' && lastPick.el === el) lastPick = null
+        } else {
+            const box = mkBox(LOCK_COLOR, 'rgba(255,45,155,0.12)')
+            placeBox(box, el)
+            wrapperLocks.set(el, box)
+            attachReposition()
+            lastPick = { kind: 'wrapper', el }
+        }
+        updatePickButton()
+    }
+
+    const clearAllLocks = () => {
+        for (const box of wrapperLocks.values()) box.remove()
+        wrapperLocks.clear()
+        detachReposition()
+        portalLockCount = 0
+        lastPick = null
+        postToPortal({ action: 'CLEAR_LOCKS' })
+        updatePickButton()
+    }
+
+    // The pick target's box in page (viewport) coordinates. For portal picks we
+    // add the iframe's current position so the alignment tracks the iframe even
+    // if the wrapper layout shifted since the pick.
+    const pickTargetPageRect = (): { x: number; y: number; width: number; height: number } | null => {
+        if (!lastPick) return null
+        if (lastPick.kind === 'wrapper') {
+            if (!lastPick.el.isConnected) return null
+            const r = lastPick.el.getBoundingClientRect()
+            return { x: r.left, y: r.top, width: r.width, height: r.height }
+        }
+        const fr = portalFrame()?.getBoundingClientRect()
+        const ox = fr ? fr.left : 0
+        const oy = fr ? fr.top : 0
+        const r = lastPick.rect
+        return { x: ox + r.x, y: oy + r.y, width: r.width, height: r.height }
+    }
+
+    // Align the overlay image to the last picked element. `scaleToWidth` also
+    // scales the image (uniformly) so its width matches the element's.
+    const alignToPick = (scaleToWidth: boolean) => {
+        const rect = pickTargetPageRect()
+        if (!rect) { pickInfo.textContent = 'Pick an element first (click one in pick mode)'; return }
+        if (!state.src) { pickInfo.textContent = 'Load an image first'; return }
+        let scale = state.scale
+        if (scaleToWidth) {
+            if (!img.naturalWidth) { pickInfo.textContent = 'Image not loaded yet'; return }
+            scale = Number((rect.width / img.naturalWidth).toFixed(4))
+        }
+        preFit = null
+        state = { ...state, x: Math.round(rect.x), y: Math.round(rect.y), scale, visible: true }
+        syncUi()
+        pickInfo.textContent = `Aligned to ${Math.round(rect.width)}×${Math.round(rect.height)}${scaleToWidth ? ` @ ${scale}×` : ''}`
+    }
+
+    const onPickMove = (e: PointerEvent) => {
+        const el = e.target as Element | null
+        // Over the iframe, the portal-side picker handles the highlight.
+        if (!el || el === portalFrame() || isOwnUi(el)) { hoverBox.style.display = 'none'; return }
+        placeBox(hoverBox, el)
+        pickInfo.textContent = describeEl(el)
+    }
+    const onPickClick = (e: MouseEvent) => {
+        const el = e.target as Element | null
+        // Let panel buttons (incl. the pick button itself) work normally;
+        // clicks inside the iframe never reach us (the portal handles them).
+        if (!el || el === portalFrame() || isOwnUi(el)) return
+        e.preventDefault()
+        e.stopPropagation()
+        toggleWrapperLock(el)
+    }
+
+    const setPickActive = (on: boolean) => {
+        if (on === pickActive) return
+        pickActive = on
+        postToPortal({ action: 'SET_PICK', enabled: on })
+        if (on) {
+            document.addEventListener('pointermove', onPickMove, true)
+            document.addEventListener('click', onPickClick, true)
+        } else {
+            document.removeEventListener('pointermove', onPickMove, true)
+            document.removeEventListener('click', onPickClick, true)
+            hoverBox.style.display = 'none'
+            pickInfo.textContent = ''
+        }
+        updatePickButton()
+    }
+
+    // Reports from the portal-side picker for elements inside the iframe: a
+    // hover/pick readout, and the iframe's locked-box count (so our button can
+    // show the combined total). The portal draws its own boxes.
+    window.addEventListener('message', (e: MessageEvent) => {
+        const d = e.data as { from?: string; action?: string; tag?: string; id?: string; count?: number; rect?: { x: number; y: number; width: number; height: number } } | null
+        if (!d || d.from !== PICK_TAG) return
+        if (d.action === 'LOCKS') {
+            portalLockCount = d.count ?? 0
+            updatePickButton()
+        } else if ((d.action === 'HOVER' || d.action === 'PICK') && pickActive) {
+            const id = d.id ? `#${d.id}` : ''
+            const size = d.rect ? ` · ${Math.round(d.rect.width)}×${Math.round(d.rect.height)}` : ''
+            pickInfo.textContent = `${d.tag ?? '?'}${id}${size}`
+            // Remember a committed pick (click) inside the iframe as the align
+            // target. rect is iframe-local; pickTargetPageRect() re-offsets it.
+            if (d.action === 'PICK' && d.rect) lastPick = { kind: 'portal', rect: d.rect }
+        }
+    })
 
     panel.addEventListener('click', (e) => {
         const t = e.target as HTMLElement
         const act = t.getAttribute('data-act')
         if (!act) return
         if (act === 'reset') { state = { ...DEFAULTS }; preFit = null; syncUi() }
+        else if (act === 'clearUrl') { state = { ...state, src: '' }; urlInput.value = ''; syncUi(); urlInput.focus() }
+        else if (act === 'paste') { void pasteFromClipboard() }
+        else if (act === 'pick') { setPickActive(!pickActive) }
+        else if (act === 'alignPick') { alignToPick(false) }
+        else if (act === 'fitPick') { alignToPick(true) }
         else if (act === 'collapse') { state = { ...state, collapsed: !state.collapsed }; syncUi() }
         else if (act === 'diff') { state = { ...state, diff: !state.diff }; syncUi() }
+        else if (act === 'invert') { state = { ...state, invert: !state.invert }; syncUi() }
         else if (act === 'border') { state = { ...state, border: !state.border }; syncUi() }
+        else if (act === 'grid') { state = { ...state, grid: !state.grid }; syncUi() }
+        else if (act === 'addGuideV') { addGuide('x') }
+        else if (act === 'addGuideH') { addGuide('y') }
+        else if (act === 'clearGuides') { state = { ...state, guides: [] }; renderGuides(); save() }
         else if (act === 'fit') {
             if (preFit) {
                 // Second click: un-fit, restoring the size/position from before.
@@ -513,8 +1038,20 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     })
 
     window.addEventListener('keydown', (e) => {
+        // Esc exits pick mode; a second Esc (or Esc when not picking) clears
+        // any locked highlights. Allowed even when a field is focused.
+        if (e.key === 'Escape') {
+            if (pickActive) { e.preventDefault(); setPickActive(false); return }
+            if (totalLocks() > 0) { e.preventDefault(); clearAllLocks(); return }
+        }
         const tgt = e.target as HTMLElement | null
         if (tgt && /^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName)) return
+        // Delete/Backspace removes the guide the pointer is hovering.
+        if ((e.key === 'Delete' || e.key === 'Backspace') && hoveredGuideId) {
+            e.preventDefault()
+            removeGuide(hoveredGuideId)
+            return
+        }
         const step = e.shiftKey ? 10 : 1
         if (e.key === 'ArrowLeft') state = { ...state, x: state.x - step }
         else if (e.key === 'ArrowRight') state = { ...state, x: state.x + step }
@@ -523,6 +1060,16 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         else return
         e.preventDefault()
         syncUi()
+    })
+
+    // Ctrl/⌘+V anywhere pastes an image (or copied Figma frame) onto the
+    // overlay. Reuses the drag&drop extractor since a ClipboardEvent's
+    // clipboardData is a DataTransfer. Ignored while typing in a field so
+    // normal text paste still works there.
+    window.addEventListener('paste', (e: ClipboardEvent) => {
+        const tgt = e.target as HTMLElement | null
+        if (tgt && /^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName)) return
+        if (loadFromDataTransfer(e.clipboardData)) e.preventDefault()
     })
 
     syncUi()

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -946,6 +946,15 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     // hover/pick readout, and the iframe's locked-box count (so our button can
     // show the combined total). The portal draws its own boxes.
     window.addEventListener('message', (e: MessageEvent) => {
+        // Only trust messages from the portal iframe itself (right window and
+        // origin), so another frame can't spoof picker events.
+        const frame = portalFrame()
+        if (frame?.contentWindow && e.source !== frame.contentWindow) return
+        if (frame?.src) {
+            let expectedOrigin: string | null = null
+            try { expectedOrigin = new URL(frame.src).origin } catch { /* bad src */ }
+            if (expectedOrigin && e.origin !== expectedOrigin) return
+        }
         const d = e.data as { from?: string; action?: string; tag?: string; id?: string; count?: number; rect?: { x: number; y: number; width: number; height: number } } | null
         if (!d || d.from !== PICK_TAG) return
         if (d.action === 'LOCKS') {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,15 @@ import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import router from './router.tsx'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { DEV_MODE } from './config'
 import './globals.css'
+
+// Dev-only: lets the dev-wrapper's visual-diff overlay highlight elements
+// inside this (cross-origin) iframe. Dynamically imported so it stays out of
+// production bundles entirely.
+if (DEV_MODE) {
+  void import('./utils/devElementPicker').then(m => m.mountDevElementPicker())
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/utils/devElementPicker.ts
+++ b/src/utils/devElementPicker.ts
@@ -1,0 +1,180 @@
+/**
+ * Dev-only element picker for the Cashback Portal.
+ *
+ * The portal renders inside a cross-origin iframe in the dev-wrapper, so the
+ * wrapper's visual-diff overlay can't reach into this document to inspect
+ * elements. This module is the portal-side half: when the wrapper turns on
+ * "pick mode" (via postMessage), it highlights the element under the cursor
+ * here, and clicking LOCKS an element (a persistent box that survives exiting
+ * pick mode). It reports geometry + the locked count back to the wrapper.
+ *
+ * It is mounted only when `DEV_MODE` is true (see main.tsx), and the whole
+ * module is dynamically imported so it never ships in a production bundle.
+ *
+ * Protocol (tag `bringweb3-devpick`, kept separate from the portal session
+ * protocol so the two never collide):
+ *   ← from wrapper: { to: 'bringweb3-devpick', action: 'SET_PICK', enabled }
+ *                   { to: 'bringweb3-devpick', action: 'CLEAR_LOCKS' }
+ *   → to wrapper:   { from: 'bringweb3-devpick', action: 'HOVER' | 'PICK',
+ *                     rect, tag, id }
+ *                   { from: 'bringweb3-devpick', action: 'LOCKS', count }
+ * `rect` is in this document's viewport coordinates; the wrapper offsets it by
+ * the iframe's position to get page coordinates.
+ */
+
+const TAG = 'bringweb3-devpick'
+const HOVER_COLOR = '#00E5FF'
+const LOCK_COLOR = '#FF2D9B'
+
+export const mountDevElementPicker = () => {
+    let enabled = false
+
+    const mkBox = (color: string, alpha: string): HTMLDivElement => {
+        const b = document.createElement('div')
+        Object.assign(b.style, {
+            position: 'fixed',
+            zIndex: '2147483647',
+            pointerEvents: 'none',
+            border: `1px solid ${color}`,
+            background: alpha,
+            boxSizing: 'border-box',
+            display: 'none',
+        } as Partial<CSSStyleDeclaration> as CSSStyleDeclaration)
+        document.body.appendChild(b)
+        return b
+    }
+    const mkLabel = (color: string): HTMLDivElement => {
+        const l = document.createElement('div')
+        Object.assign(l.style, {
+            position: 'fixed',
+            zIndex: '2147483647',
+            pointerEvents: 'none',
+            background: color,
+            color: '#04222a',
+            font: '10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace',
+            padding: '1px 4px',
+            borderRadius: '3px',
+            whiteSpace: 'nowrap',
+            display: 'none',
+        } as Partial<CSSStyleDeclaration> as CSSStyleDeclaration)
+        document.body.appendChild(l)
+        return l
+    }
+
+    const hoverBox = mkBox(HOVER_COLOR, 'rgba(0,229,255,0.12)')
+    const hoverLabel = mkLabel(HOVER_COLOR)
+    // Locked elements each keep a persistent box + label.
+    const locked = new Map<Element, { box: HTMLDivElement; label: HTMLDivElement }>()
+
+    const describe = (el: Element): string => {
+        const r = el.getBoundingClientRect()
+        const id = (el as HTMLElement).id ? `#${(el as HTMLElement).id}` : ''
+        return `${el.tagName.toLowerCase()}${id} · ${Math.round(r.width)}×${Math.round(r.height)}`
+    }
+    const place = (box: HTMLDivElement, label: HTMLDivElement, el: Element) => {
+        const r = el.getBoundingClientRect()
+        Object.assign(box.style, {
+            display: '', left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px`,
+        })
+        label.textContent = describe(el)
+        label.style.display = ''
+        label.style.left = `${r.left}px`
+        label.style.top = r.top - 16 < 0 ? `${r.top + 2}px` : `${r.top - 16}px`
+    }
+
+    const post = (action: string, extra: Record<string, unknown> = {}) => {
+        window.parent.postMessage({ from: TAG, action, ...extra }, '*')
+    }
+    const postHover = (action: 'HOVER' | 'PICK', el: Element) => {
+        const r = el.getBoundingClientRect()
+        post(action, {
+            rect: { x: r.left, y: r.top, width: r.width, height: r.height },
+            tag: el.tagName.toLowerCase(),
+            id: (el as HTMLElement).id || '',
+        })
+    }
+    const postLocks = () => post('LOCKS', { count: locked.size })
+
+    // Keep locked boxes pinned to their elements as the portal scrolls/resizes.
+    let reposAttached = false
+    const reposition = () => {
+        for (const [el, rec] of locked) {
+            if (!el.isConnected) { rec.box.remove(); rec.label.remove(); locked.delete(el); continue }
+            place(rec.box, rec.label, el)
+        }
+        if (locked.size === 0) detachReposition()
+    }
+    const attachReposition = () => {
+        if (reposAttached) return
+        reposAttached = true
+        window.addEventListener('scroll', reposition, true)
+        window.addEventListener('resize', reposition)
+    }
+    function detachReposition() {
+        if (!reposAttached) return
+        reposAttached = false
+        window.removeEventListener('scroll', reposition, true)
+        window.removeEventListener('resize', reposition)
+    }
+
+    const toggleLock = (el: Element) => {
+        const existing = locked.get(el)
+        if (existing) {
+            existing.box.remove(); existing.label.remove(); locked.delete(el)
+            if (locked.size === 0) detachReposition()
+        } else {
+            const box = mkBox(LOCK_COLOR, 'rgba(255,45,155,0.12)')
+            const label = mkLabel(LOCK_COLOR)
+            place(box, label, el)
+            locked.set(el, { box, label })
+            attachReposition()
+        }
+        postLocks()
+    }
+    const clearLocks = () => {
+        for (const { box, label } of locked.values()) { box.remove(); label.remove() }
+        locked.clear()
+        detachReposition()
+        postLocks()
+    }
+
+    const onMove = (e: PointerEvent) => {
+        const el = e.target as Element | null
+        if (!el || el === hoverBox || el === hoverLabel) return
+        place(hoverBox, hoverLabel, el)
+        postHover('HOVER', el)
+    }
+    // Swallow the click so locking an element never triggers the portal's own
+    // UI (navigation, buttons, …).
+    const onClick = (e: MouseEvent) => {
+        const el = e.target as Element | null
+        if (!el) return
+        e.preventDefault()
+        e.stopPropagation()
+        toggleLock(el)
+        postHover('PICK', el)
+    }
+
+    const setEnabled = (on: boolean) => {
+        if (on === enabled) return
+        enabled = on
+        if (on) {
+            document.addEventListener('pointermove', onMove, true)
+            document.addEventListener('click', onClick, true)
+            document.body.style.cursor = 'crosshair'
+        } else {
+            document.removeEventListener('pointermove', onMove, true)
+            document.removeEventListener('click', onClick, true)
+            document.body.style.cursor = ''
+            hoverBox.style.display = 'none'
+            hoverLabel.style.display = 'none'
+        }
+    }
+
+    window.addEventListener('message', (e: MessageEvent) => {
+        const d = e.data as { to?: string; action?: string; enabled?: boolean } | null
+        if (!d || d.to !== TAG) return
+        if (d.action === 'SET_PICK') setEnabled(!!d.enabled)
+        else if (d.action === 'CLEAR_LOCKS') clearLocks()
+    })
+}

--- a/src/utils/devElementPicker.ts
+++ b/src/utils/devElementPicker.ts
@@ -172,6 +172,8 @@ export const mountDevElementPicker = () => {
     }
 
     window.addEventListener('message', (e: MessageEvent) => {
+        // Only the embedding wrapper (our parent) may drive the picker.
+        if (e.source !== window.parent) return
         const d = e.data as { to?: string; action?: string; enabled?: boolean } | null
         if (!d || d.to !== TAG) return
         if (d.action === 'SET_PICK') setEnabled(!!d.enabled)


### PR DESCRIPTION
…invert, element inspector

Visual-diff overlay (dev-wrapper/visualDiffOverlay.ts):
- Add "invert" toggle (filter: invert(1)) for the overlay image
- Add a full-page pixel ruler grid with adjustable cell size and color
- Add draggable guide lines (+vert / +horz) with live px readout; double-click or hover + Delete to remove one, "clear" / Esc to remove all; persisted
- Add clipboard paste: Ctrl/Cmd+V anywhere, plus a "paste" button
- Redesign the URL row as a flexible inline field and add focus-ring styling across all panel inputs
- Add an element inspector ("pick"): highlight elements with a tag/size readout; click to lock a persistent highlight; locks reposition on scroll/resize; Esc clears
- Add "align" / "fit->pick": snap the overlay image to the last picked element
- Gate the inspector UI to localhost only (hidden on the hosted build)

Portal element picker (src/utils/devElementPicker.ts, src/main.tsx):
- New dev-only module that highlights/locks elements inside the cross-origin portal iframe and reports geometry to the wrapper over postMessage
- Mounted only when DEV_MODE and dynamically imported, so it never ships in a production portal bundle