### PR TITLE
feat(dev-wrapper): add measure tools, better layering

### DIFF
--- a/dev-wrapper/index.html
+++ b/dev-wrapper/index.html
@@ -72,16 +72,8 @@
                         </select>
                     </label>
                     <label class="row">
-                        <input id="startDisconnected" type="checkbox" checked />
-                        <span>Start disconnected</span>
-                    </label>
-                    <label class="row">
-                        <input id="autoConnect" type="checkbox" checked />
-                        <span>Auto-respond to LOGIN</span>
-                    </label>
-                    <label class="row">
-                        <input id="autoSign" type="checkbox" checked />
-                        <span>Auto-respond to SIGN_MESSAGE</span>
+                        <input id="startConnected" type="checkbox" />
+                        <span>Start connected</span>
                     </label>
                     <div class="btn-row">
                         <button id="manualConnect" type="button" class="secondary">Send connect</button>

--- a/dev-wrapper/main.ts
+++ b/dev-wrapper/main.ts
@@ -93,11 +93,14 @@ const lastTokenRawEl = $<HTMLTextAreaElement>('lastTokenRaw')
 const lastTokenDecodedEl = $<HTMLDivElement>('lastTokenDecoded')
 const statusEl = $<HTMLParagraphElement>('status')
 
-const STARTED_DISCONNECTED_KEY = 'bring-dev-wrapper:start-disconnected'
-const startDisconnectedDefault = localStorage.getItem(STARTED_DISCONNECTED_KEY) !== '0'
+const START_CONNECTED_KEY = 'bring-dev-wrapper:start-connected'
+const startConnected = localStorage.getItem(START_CONNECTED_KEY) === '1'
 
 extensionEl.value = DEFAULT_EXT_ID
-walletEl.value = startDisconnectedDefault ? '' : DEFAULT_WALLET
+// Wallet starts empty; if "Start connected" is on and the provider is mock, we
+// pre-fill the default address below (once the active provider is known) so the
+// first bootstrap logs the portal in.
+walletEl.value = ''
 themeEl.value = DEFAULT_THEME === 'dark' || DEFAULT_THEME === 'light' ? DEFAULT_THEME : ''
 apiStageInfoEl.textContent = apiStage || '(default)'
 
@@ -110,12 +113,10 @@ toggleBtn.addEventListener('click', () => {
     localStorage.setItem(SIDEBAR_KEY, collapsed ? '1' : '0')
 })
 
-const autoConnectEl = $<HTMLInputElement>('autoConnect')
-const autoSignEl = $<HTMLInputElement>('autoSign')
-const startDisconnectedEl = $<HTMLInputElement>('startDisconnected')
-startDisconnectedEl.checked = startDisconnectedDefault
-startDisconnectedEl.addEventListener('change', () => {
-    localStorage.setItem(STARTED_DISCONNECTED_KEY, startDisconnectedEl.checked ? '1' : '0')
+const startConnectedEl = $<HTMLInputElement>('startConnected')
+startConnectedEl.checked = startConnected
+startConnectedEl.addEventListener('change', () => {
+    localStorage.setItem(START_CONNECTED_KEY, startConnectedEl.checked ? '1' : '0')
 })
 const manualConnectBtn = $<HTMLButtonElement>('manualConnect')
 const manualAbortBtn = $<HTMLButtonElement>('manualAbort')
@@ -315,8 +316,8 @@ const bridge = createPortalBridge({
     iframe: iframeEl,
     wallet: walletProxy,
     log: appendLog,
-    shouldAutoConnect: () => autoConnectEl.checked,
-    shouldAutoSign: () => autoSignEl.checked,
+    // LOGIN / SIGN_MESSAGE are always auto-answered (the bridge defaults to
+    // responding); the old opt-out toggles were removed.
     refreshToken: async (address) => {
         const data = await bootstrap(address)
         return data?.token ?? null
@@ -328,12 +329,22 @@ const bridge = createPortalBridge({
     },
 })
 
-// If the wrapper started with a wallet pre-filled ("start disconnected" off)
-// AND the mock provider is active, pre-connect the mock wallet so its
-// internal state matches the UI. External providers (e.g. nightly) drive
-// the address themselves on connect, so we never auto-poke them here.
-if (activeProvider === 'mock' && walletEl.value.trim()) {
-    void mockAdapter.connect(walletEl.value.trim())
+// "Start connected": bring the wallet up on load.
+//  - mock: pre-fill the default address so the first bootstrap logs the portal
+//    in, and sync the mock adapter's internal state to match.
+//  - external: the extension owns the address, so we can't fill it in up front;
+//    instead connect once the portal iframe has loaded, which prompts the
+//    extension if it's available ("if possible").
+if (startConnected) {
+    if (activeProvider === 'mock') {
+        if (DEFAULT_WALLET.trim()) {
+            walletEl.value = DEFAULT_WALLET
+            setWalletButton(DEFAULT_WALLET.trim())
+            void mockAdapter.connect(DEFAULT_WALLET.trim())
+        }
+    } else {
+        iframeEl.addEventListener('load', () => { void bridge.connect() }, { once: true })
+    }
 }
 
 manualConnectBtn.addEventListener('click', () => {

--- a/dev-wrapper/style.css
+++ b/dev-wrapper/style.css
@@ -14,6 +14,9 @@ html, body {
     display: flex;
     align-items: center;
     gap: 16px;
+    /* Slightly lighter slate than the body/sidebar (#0f1115) so the header reads
+       as its own element. Stays in normal flow (under the overlay layers). */
+    background: #181d25;
 }
 
 .bar-text { flex: 1; min-width: 0; }
@@ -80,6 +83,11 @@ html, body {
     margin-left: 4px;
     padding-left: 16px;
     border-left: 1px solid #2a313c;
+    /* Dev-only control (clears hosted basic-auth) — keep it above the visual-
+       diff overlay layers like the side panel, even though the rest of the
+       header sits under them as page content. See Z_LAYER in visualDiffOverlay.ts. */
+    position: relative;
+    z-index: 2147483640;
     background: transparent;
     color: #8a93a3;
     border-top: 0;
@@ -127,7 +135,9 @@ html, body {
     top: 12px;
     left: 320px;
     transform: translateX(-50%);
-    z-index: 10;
+    /* Above the sidebar (and the overlay layers) so the collapse tab is always
+       clickable; still below the overlay's control panel. */
+    z-index: 2147483641;
     width: 22px;
     height: 36px;
     border: 1px solid #2a313c;
@@ -159,6 +169,50 @@ html, body {
     padding: 16px;
     overflow: auto;
     border-right: 1px solid #1f242c;
+    /* Sit above the visual-diff overlay layers so the dev controls are never
+       covered by the design image / grid / guides / rulers. Only the sidebar is
+       raised — NOT .layout — so the overlay still renders over the portal
+       iframe. The opaque background is what actually OCCLUDES the overlay; a
+       raised z-index alone shows through (the panel was transparent before).
+       See Z_LAYER in visualDiffOverlay.ts. */
+    position: relative;
+    z-index: 2147483640;
+    background: #0f1115;
+}
+
+/* Slim, theme-matched scrollbar for the sidebar and any scrollable panes inside
+   it (event log, JSON previews), replacing the chunky default OS bar. Firefox
+   uses scrollbar-*; Chromium/WebKit uses ::-webkit-scrollbar. The thumb floats
+   with a transparent border via background-clip so it reads as a thin pill. */
+.controls,
+.controls * {
+    scrollbar-width: thin;
+    scrollbar-color: #353c47 transparent;
+}
+.controls::-webkit-scrollbar,
+.controls *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+.controls::-webkit-scrollbar-track,
+.controls *::-webkit-scrollbar-track {
+    background: transparent;
+}
+.controls::-webkit-scrollbar-thumb,
+.controls *::-webkit-scrollbar-thumb {
+    background: #353c47;
+    border-radius: 999px;
+    border: 3px solid transparent;
+    background-clip: padding-box;
+}
+.controls::-webkit-scrollbar-thumb:hover,
+.controls *::-webkit-scrollbar-thumb:hover {
+    background: #454e5d;
+    background-clip: padding-box;
+}
+.controls::-webkit-scrollbar-corner,
+.controls *::-webkit-scrollbar-corner {
+    background: transparent;
 }
 
 .controls fieldset {

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -70,7 +70,9 @@ const FIGMA_TOKEN_KEY = 'bring.visualDiff.figmaToken'
 // band down uniformly, preserving the layers' relative order. The matching
 // chrome z-index lives in style.css (.bar / .controls / .toggle).
 const Z_LAYER = '2147483600'
-const Z_DROP_HINT = '2147483599'
+// Above the overlay layers (so the dimmer/affordance is never hidden behind an
+// active image/grid/guides while dragging) but below the panel (kept usable).
+const Z_DROP_HINT = '2147483639'
 const Z_PANEL = '2147483647'
 
 // Pull the file key + node id out of a Figma URL (design/file/board/proto).
@@ -775,7 +777,15 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     // `reset` never moves it.
     const PANEL_POS_KEY = 'bring.visualDiff.panelPos'
     const loadPanelPos = (): { left: number; top: number } | null => {
-        try { const raw = localStorage.getItem(PANEL_POS_KEY); return raw ? JSON.parse(raw) : null } catch { return null }
+        try {
+            const raw = localStorage.getItem(PANEL_POS_KEY)
+            if (!raw) return null
+            const p = JSON.parse(raw)
+            // Reject malformed/partial values - otherwise NaN flows into
+            // applyPanelPos and writes `NaNpx`, losing the panel off-screen.
+            if (p && Number.isFinite(p.left) && Number.isFinite(p.top)) return { left: p.left, top: p.top }
+            return null
+        } catch { return null }
     }
     let panelPos = loadPanelPos()
     const savePanelPos = () => {

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -17,6 +17,8 @@
  *   - `grid` toggles a full-page pixel ruler grid (adjustable cell size/color)
  *   - `+ vert` / `+ horz` drop draggable guide lines (double-click one to
  *     remove it, `clear` removes all); each shows a live px readout
+ *   - `ruler` arms a measuring tape: press-drag between two dots to read the
+ *     pixel distance; both dots stay draggable (double-click / Delete removes)
  *   - `hide` / `lock` / `reset`
  *
  * Note: this overlays the dev-wrapper page itself, NOT the portal rendered
@@ -28,6 +30,10 @@
 // (pos = its left/x coordinate); `axis: 'y'` is a horizontal line movable
 // vertically (pos = its top/y coordinate). Coordinates are viewport CSS px.
 type Guide = { id: string; axis: 'x' | 'y'; pos: number }
+
+// A free-angle measuring tape between two viewport points (CSS px). The label
+// shows the straight-line distance between them.
+type Ruler = { id: string; x1: number; y1: number; x2: number; y2: number }
 
 type State = {
     src: string
@@ -45,6 +51,7 @@ type State = {
     gridSize: number
     gridColor: string
     guides: Guide[]
+    rulers: Ruler[]
 }
 
 const STORAGE_KEY = 'bring.visualDiff.wrapper.v1'
@@ -54,6 +61,17 @@ const STORAGE_KEY = 'bring.visualDiff.wrapper.v1'
 // REST API (used when the dev-only `/__figma-image` proxy isn't available,
 // e.g. on the static hosted build).
 const FIGMA_TOKEN_KEY = 'bring.visualDiff.figmaToken'
+
+// Stacking bands. The overlay's own layers (design image, grid, guides, rulers,
+// pick boxes) sit just below the very top so the dev wrapper's chrome (header +
+// sidebar) can be raised ABOVE them — that chrome is tooling, not page content,
+// so it shouldn't be covered by the design/guides/grid. The draggable control
+// panel stays at the very top, above everything. These shift the whole overlay
+// band down uniformly, preserving the layers' relative order. The matching
+// chrome z-index lives in style.css (.bar / .controls / .toggle).
+const Z_LAYER = '2147483600'
+const Z_DROP_HINT = '2147483599'
+const Z_PANEL = '2147483647'
 
 // Pull the file key + node id out of a Figma URL (design/file/board/proto).
 const parseFigmaUrl = (url: string): { fileKey: string; nodeId: string } | null => {
@@ -78,6 +96,7 @@ const DEFAULTS: State = {
     gridSize: 8,
     gridColor: '#FF2D9B',
     guides: [],
+    rulers: [],
 }
 
 const loadState = (): State => {
@@ -146,7 +165,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         top: '0',
         left: '0',
         transformOrigin: 'top left',
-        zIndex: '2147483646',
+        zIndex: Z_LAYER,
         userSelect: 'none',
     } as CSSStyleDeclaration)
     document.body.appendChild(img)
@@ -209,7 +228,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     Object.assign(grid.style, {
         position: 'fixed',
         inset: '0',
-        zIndex: '2147483646',
+        zIndex: Z_LAYER,
         pointerEvents: 'none',
         display: 'none',
     } as CSSStyleDeclaration)
@@ -279,7 +298,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         const vertical = guide.axis === 'x'
         Object.assign(el.style, {
             position: 'fixed',
-            zIndex: '2147483646',
+            zIndex: Z_LAYER,
             background: vertical
                 ? `linear-gradient(to right, transparent 4px, ${GUIDE_COLOR} 4px, ${GUIDE_COLOR} 5px, transparent 5px)`
                 : `linear-gradient(to bottom, transparent 4px, ${GUIDE_COLOR} 4px, ${GUIDE_COLOR} 5px, transparent 5px)`,
@@ -367,13 +386,172 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         save()
     }
 
+    // --- distance rulers ---------------------------------------------------
+    // Free-angle measuring tapes. Arm with the "ruler" button, then press-drag
+    // anywhere to stretch a line between two dots; the label shows its pixel
+    // length. Both endpoints stay draggable afterward (pointer capture keeps the
+    // drag alive over the cross-origin iframe). Double-click a dot or press
+    // Delete while hovering one to remove it; "clear" removes all. Rulers live
+    // in STATE so they persist across reloads. `rulerArmed` is transient (draw
+    // mode), driven by the catcher set up after the panel is built.
+    const RULER_COLOR = '#FFB020'
+    const SVG_NS = 'http://www.w3.org/2000/svg'
+    const rulerEls = new Map<string, HTMLDivElement>()
+    let rulerSeq = state.rulers.reduce((m, r) => {
+        const n = Number(r.id.replace(/^r/, ''))
+        return Number.isFinite(n) ? Math.max(m, n + 1) : m
+    }, 1)
+    let hoveredRulerId: string | null = null
+    let rulerArmed = false
+
+    // With Shift held, snap a stretched endpoint to a pure horizontal or
+    // vertical line relative to the anchor (whichever axis the drag favours),
+    // so the ruler stays axis-aligned instead of diagonal.
+    const constrainToAxis = (ax: number, ay: number, bx: number, by: number, shift: boolean) =>
+        !shift ? { x: bx, y: by }
+            : Math.abs(bx - ax) >= Math.abs(by - ay) ? { x: bx, y: ay } : { x: ax, y: by }
+
+    const removeRuler = (id: string) => {
+        state = { ...state, rulers: state.rulers.filter(r => r.id !== id) }
+        if (hoveredRulerId === id) hoveredRulerId = null
+        renderRulers()
+        save()
+    }
+
+    const positionRuler = (id: string) => {
+        const el = rulerEls.get(id)
+        const r = state.rulers.find(rr => rr.id === id)
+        if (!el || !r) return
+        const line = el.querySelector('line') as SVGLineElement | null
+        if (line) {
+            line.setAttribute('x1', String(r.x1)); line.setAttribute('y1', String(r.y1))
+            line.setAttribute('x2', String(r.x2)); line.setAttribute('y2', String(r.y2))
+        }
+        const h1 = el.querySelector('[data-h="1"]') as HTMLElement | null
+        const h2 = el.querySelector('[data-h="2"]') as HTMLElement | null
+        if (h1) { h1.style.left = `${r.x1}px`; h1.style.top = `${r.y1}px` }
+        if (h2) { h2.style.left = `${r.x2}px`; h2.style.top = `${r.y2}px` }
+        const dx = r.x2 - r.x1, dy = r.y2 - r.y1
+        const dist = Math.hypot(dx, dy)
+        const len = Math.round(dist)
+        const label = el.querySelector('[data-el="rulerLabel"]') as HTMLElement | null
+        if (label) {
+            label.textContent = `${len}px`
+            label.title = `Δx ${Math.abs(dx)} · Δy ${Math.abs(dy)}`
+            // Sit the label OFF the line (perpendicular to it), biased to the
+            // upper side, so short rulers stay readable instead of being squashed
+            // onto the endpoint dots. Falls back to the midpoint for zero length.
+            const off = 14
+            let ox = dist ? (-dy / dist) * off : 0
+            let oy = dist ? (dx / dist) * off : -off
+            if (oy > 0) { ox = -ox; oy = -oy }
+            label.style.left = `${(r.x1 + r.x2) / 2 + ox}px`
+            label.style.top = `${(r.y1 + r.y2) / 2 + oy}px`
+        }
+    }
+
+    const makeRulerEl = (ruler: Ruler): HTMLDivElement => {
+        // Full-viewport container; only the endpoint dots take pointer events so
+        // the rest of the page stays clickable through it.
+        const container = document.createElement('div')
+        Object.assign(container.style, {
+            position: 'fixed', inset: '0', zIndex: Z_LAYER, pointerEvents: 'none',
+        } as CSSStyleDeclaration)
+
+        const svg = document.createElementNS(SVG_NS, 'svg')
+        Object.assign(svg.style, { position: 'absolute', inset: '0', width: '100%', height: '100%', overflow: 'visible' } as CSSStyleDeclaration)
+        const line = document.createElementNS(SVG_NS, 'line')
+        line.setAttribute('stroke', RULER_COLOR)
+        line.setAttribute('stroke-width', '1')
+        line.setAttribute('stroke-dasharray', '4 3')
+        svg.appendChild(line)
+        container.appendChild(svg)
+
+        const label = document.createElement('div')
+        label.setAttribute('data-el', 'rulerLabel')
+        Object.assign(label.style, {
+            position: 'absolute', background: RULER_COLOR, color: '#1F2018',
+            font: '10px/1 ui-monospace, SFMono-Regular, Menlo, monospace',
+            padding: '1px 4px', borderRadius: '3px', whiteSpace: 'nowrap',
+            pointerEvents: 'none', transform: 'translate(-50%, -50%)',
+        } as CSSStyleDeclaration)
+        container.appendChild(label)
+
+        const mkHandle = (which: 1 | 2): HTMLDivElement => {
+            const h = document.createElement('div')
+            h.setAttribute('data-h', String(which))
+            Object.assign(h.style, {
+                position: 'absolute', width: '11px', height: '11px',
+                marginLeft: '-6px', marginTop: '-6px', borderRadius: '50%',
+                background: RULER_COLOR, border: '1px solid #1F2018', boxSizing: 'border-box',
+                pointerEvents: 'auto', cursor: 'grab', touchAction: 'none',
+            } as CSSStyleDeclaration)
+            h.title = 'Drag to move · double-click or Delete to remove'
+            h.addEventListener('pointerenter', () => { hoveredRulerId = ruler.id })
+            h.addEventListener('pointerleave', () => { if (hoveredRulerId === ruler.id) hoveredRulerId = null })
+            h.addEventListener('pointerdown', (e: PointerEvent) => {
+                e.preventDefault(); e.stopPropagation()
+                h.setPointerCapture(e.pointerId)
+                const kx = which === 1 ? 'x1' : 'x2'
+                const ky = which === 1 ? 'y1' : 'y2'
+                const move = (ev: PointerEvent) => {
+                    // Anchor on the opposite endpoint so Shift keeps the line
+                    // horizontal/vertical relative to the fixed end.
+                    const cur = state.rulers.find(r => r.id === ruler.id)
+                    const ax = which === 1 ? (cur?.x2 ?? ev.clientX) : (cur?.x1 ?? ev.clientX)
+                    const ay = which === 1 ? (cur?.y2 ?? ev.clientY) : (cur?.y1 ?? ev.clientY)
+                    const p = constrainToAxis(ax, ay, ev.clientX, ev.clientY, ev.shiftKey)
+                    state = { ...state, rulers: state.rulers.map(r => r.id === ruler.id ? { ...r, [kx]: Math.round(p.x), [ky]: Math.round(p.y) } : r) }
+                    positionRuler(ruler.id)
+                }
+                const up = (ev: PointerEvent) => {
+                    h.removeEventListener('pointermove', move)
+                    h.removeEventListener('pointerup', up)
+                    h.removeEventListener('pointercancel', up)
+                    try { h.releasePointerCapture(ev.pointerId) } catch { /* already released */ }
+                    save()
+                }
+                h.addEventListener('pointermove', move)
+                h.addEventListener('pointerup', up)
+                h.addEventListener('pointercancel', up)
+            })
+            h.addEventListener('dblclick', (e) => { e.preventDefault(); e.stopPropagation(); removeRuler(ruler.id) })
+            return h
+        }
+        container.append(mkHandle(1), mkHandle(2))
+        return container
+    }
+
+    // Reconcile ruler DOM to state.rulers (add new, drop removed, reposition).
+    function renderRulers() {
+        const ids = new Set(state.rulers.map(r => r.id))
+        for (const [id, el] of rulerEls) {
+            if (!ids.has(id)) { el.remove(); rulerEls.delete(id) }
+        }
+        for (const ruler of state.rulers) {
+            if (!rulerEls.has(ruler.id)) {
+                const el = makeRulerEl(ruler)
+                rulerEls.set(ruler.id, el)
+                document.body.appendChild(el)
+            }
+            positionRuler(ruler.id)
+        }
+    }
+
+    const addRuler = (x1: number, y1: number, x2: number, y2: number): string => {
+        const id = `r${rulerSeq++}`
+        state = { ...state, rulers: [...state.rulers, { id, x1, y1, x2, y2 }] }
+        renderRulers()
+        return id
+    }
+
     // --- control panel -----------------------------------------------------
     const panel = document.createElement('div')
     Object.assign(panel.style, {
         position: 'fixed',
         top: '64px',
         right: '8px',
-        zIndex: '2147483647',
+        zIndex: Z_PANEL,
         background: 'rgba(20,22,28,0.92)',
         color: '#F5F8FF',
         font: '12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace',
@@ -488,12 +666,17 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             <button data-act="addGuideH" title="Add a horizontal guide (drag it vertically)" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">+ horz</button>
             <button data-act="clearGuides" title="Remove all guides" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">clear</button>
         </div>
+        <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
+            <span style="width:56px;color:#9aa0a6">Measure</span>
+            <button data-act="ruler" title="Measure a distance: click this, then press-drag between two points. Drag the dots to adjust; double-click a dot or press Delete to remove." style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">ruler</button>
+            <button data-act="clearRulers" title="Remove all measuring lines" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">clear</button>
+        </div>
         <div data-el="inspectRow">
             <div style="display:flex;align-items:center;gap:4px;margin-top:6px;flex-wrap:wrap">
                 <span style="width:56px;color:#9aa0a6">Inspect</span>
                 <button data-act="pick" title="Highlight elements under the cursor (works inside the portal iframe too); click to lock — Esc to stop / clear" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">pick</button>
                 <button data-act="alignPick" title="Move the overlay image's top-left onto the last picked element (keeps scale)" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">align</button>
-                <button data-act="fitPick" title="Scale the overlay to the picked element's width, then align to it" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">fit→pick</button>
+                <button data-act="measurePicks" title="Measure the distance between the two most-recently picked elements (draws a ruler between their nearest edges)" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">↔ measure</button>
             </div>
             <div data-el="pickInfo" style="margin-top:4px;color:#9aa0a6;font-size:11px;min-height:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis"></div>
         </div>
@@ -519,6 +702,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     const gridBtn = q<HTMLButtonElement>('[data-act="grid"]')
     const gridSizeInput = q<HTMLInputElement>('[data-el="gridSize"]')
     const gridColorInput = q<HTMLInputElement>('[data-el="gridColor"]')
+    const rulerBtn = q<HTMLButtonElement>('[data-act="ruler"]')
     const pickBtn = q<HTMLButtonElement>('[data-act="pick"]')
     const pickInfo = q<HTMLElement>('[data-el="pickInfo"]')
     const inspectRow = q<HTMLDivElement>('[data-el="inspectRow"]')
@@ -535,6 +719,131 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     const resetBtn = q<HTMLButtonElement>('[data-el="resetBtn"]')
     const titleEl = q<HTMLElement>('[data-el="title"]')
     const body = q<HTMLDivElement>('[data-el="body"]')
+
+    // --- ruler draw mode ---------------------------------------------------
+    // While armed, a transparent full-viewport catcher (above the iframe, below
+    // the panel) captures a press-drag to stretch a new ruler. Pointer capture
+    // keeps the drag tracking even over the cross-origin portal iframe. Stays
+    // armed after a draw so several measurements are quick; Esc / the button
+    // disarm it.
+    const rulerCatcher = document.createElement('div')
+    Object.assign(rulerCatcher.style, {
+        position: 'fixed', inset: '0', zIndex: Z_LAYER,
+        cursor: 'crosshair', display: 'none', touchAction: 'none',
+    } as CSSStyleDeclaration)
+    document.body.appendChild(rulerCatcher)
+
+    const setRulerArmed = (on: boolean) => {
+        rulerArmed = on
+        rulerCatcher.style.display = on ? '' : 'none'
+        rulerBtn.textContent = on ? 'drawing… (Esc)' : 'ruler'
+        rulerBtn.style.background = on ? '#FFEF46' : '#2a2d33'
+        rulerBtn.style.color = on ? '#1F2018' : '#F5F8FF'
+    }
+
+    rulerCatcher.addEventListener('pointerdown', (e: PointerEvent) => {
+        e.preventDefault()
+        rulerCatcher.setPointerCapture(e.pointerId)
+        const x = Math.round(e.clientX), y = Math.round(e.clientY)
+        const id = addRuler(x, y, x, y)
+        const move = (ev: PointerEvent) => {
+            // Anchor on the press point so Shift constrains to H/V from there.
+            const p = constrainToAxis(x, y, ev.clientX, ev.clientY, ev.shiftKey)
+            state = { ...state, rulers: state.rulers.map(r => r.id === id ? { ...r, x2: Math.round(p.x), y2: Math.round(p.y) } : r) }
+            positionRuler(id)
+        }
+        const up = (ev: PointerEvent) => {
+            rulerCatcher.removeEventListener('pointermove', move)
+            rulerCatcher.removeEventListener('pointerup', up)
+            rulerCatcher.removeEventListener('pointercancel', up)
+            try { rulerCatcher.releasePointerCapture(ev.pointerId) } catch { /* already released */ }
+            // A plain click (no real drag) leaves a degenerate ruler — drop it.
+            const r = state.rulers.find(rr => rr.id === id)
+            if (r && Math.hypot(r.x2 - r.x1, r.y2 - r.y1) < 3) removeRuler(id)
+            else save()
+        }
+        rulerCatcher.addEventListener('pointermove', move)
+        rulerCatcher.addEventListener('pointerup', up)
+        rulerCatcher.addEventListener('pointercancel', up)
+    })
+
+    // --- movable panel -----------------------------------------------------
+    // Drag the title bar to reposition the whole panel (e.g. to the left when
+    // you're working on the right of the screen). Double-click the title to snap
+    // it back to the default top-right dock. The position lives under its own
+    // localStorage key — a UI preference, independent of the diff STATE, so
+    // `reset` never moves it.
+    const PANEL_POS_KEY = 'bring.visualDiff.panelPos'
+    const loadPanelPos = (): { left: number; top: number } | null => {
+        try { const raw = localStorage.getItem(PANEL_POS_KEY); return raw ? JSON.parse(raw) : null } catch { return null }
+    }
+    let panelPos = loadPanelPos()
+    const savePanelPos = () => {
+        if (panelPos) localStorage.setItem(PANEL_POS_KEY, JSON.stringify(panelPos))
+        else localStorage.removeItem(PANEL_POS_KEY)
+    }
+    // Place the panel at its dragged position, clamped so the title bar always
+    // stays on-screen. When collapsed, the slim tab still docks to the NEARER
+    // vertical edge (keeping its height) rather than floating mid-screen at the
+    // dragged spot. When unset, restore the default top-right dock.
+    function applyPanelPos() {
+        if (!panelPos) {
+            panel.style.left = 'auto'
+            panel.style.top = '64px'
+            return
+        }
+        const top = Math.min(Math.max(0, panelPos.top), Math.max(0, window.innerHeight - 24))
+        panel.style.top = `${top}px`
+        if (state.collapsed) {
+            // Dock the tab to whichever edge the panel is closer to (~240px wide
+            // expanded, so its centre is left + 120).
+            const dockLeft = panelPos.left + 120 < window.innerWidth / 2
+            if (dockLeft) {
+                panel.style.left = '0'; panel.style.right = 'auto'
+                panel.style.borderRadius = '0 8px 8px 0'
+            } else {
+                panel.style.left = 'auto'; panel.style.right = '0'
+                panel.style.borderRadius = '8px 0 0 8px'
+            }
+        } else {
+            const left = Math.min(Math.max(0, panelPos.left), Math.max(0, window.innerWidth - 60))
+            panel.style.left = `${left}px`; panel.style.right = 'auto'
+            panel.style.borderRadius = '8px'
+        }
+    }
+    titleEl.style.cursor = 'move'
+    titleEl.title = 'Drag to move the panel · double-click to reset position'
+    titleEl.addEventListener('pointerdown', (e: PointerEvent) => {
+        e.preventDefault()
+        titleEl.setPointerCapture(e.pointerId)
+        // Base off the live rect so the first drag from the docked position
+        // converts seamlessly to left/top coordinates.
+        const rect = panel.getBoundingClientRect()
+        const startX = e.clientX, startY = e.clientY
+        const baseLeft = rect.left, baseTop = rect.top
+        const move = (ev: PointerEvent) => {
+            panelPos = { left: Math.round(baseLeft + (ev.clientX - startX)), top: Math.round(baseTop + (ev.clientY - startY)) }
+            applyPanelPos()
+        }
+        const up = (ev: PointerEvent) => {
+            titleEl.removeEventListener('pointermove', move)
+            titleEl.removeEventListener('pointerup', up)
+            titleEl.removeEventListener('pointercancel', up)
+            try { titleEl.releasePointerCapture(ev.pointerId) } catch { /* already released */ }
+            savePanelPos()
+        }
+        titleEl.addEventListener('pointermove', move)
+        titleEl.addEventListener('pointerup', up)
+        titleEl.addEventListener('pointercancel', up)
+    })
+    titleEl.addEventListener('dblclick', (e) => {
+        e.preventDefault()
+        panelPos = null
+        savePanelPos()
+        syncUi()
+    })
+    // Keep the panel on-screen if the window shrinks under it.
+    window.addEventListener('resize', () => { if (panelPos) applyPanelPos() })
 
     // Restore the saved Figma token (if any) and persist edits as they happen.
     figmaTokenInput.value = localStorage.getItem(FIGMA_TOKEN_KEY) ?? ''
@@ -609,9 +918,13 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             panel.style.right = '8px'
             panel.style.borderRadius = '8px'
         }
+        // Apply a user-dragged position last so it overrides the default
+        // right-edge docking above (no-op until the panel has been moved).
+        applyPanelPos()
         applyImg()
         applyGrid()
         renderGuides()
+        renderRulers()
         save()
     }
 
@@ -770,11 +1083,14 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         | { kind: 'wrapper'; el: Element }
         | { kind: 'portal'; rect: { x: number; y: number; width: number; height: number } }
     let lastPick: PickTarget | null = null
+    // The pick before `lastPick`, so "measure" can span the two most-recently
+    // clicked elements (wrapper or portal). Updated on every committed pick.
+    let prevPick: PickTarget | null = null
 
     const mkBox = (color: string, alpha: string) => {
         const b = document.createElement('div')
         Object.assign(b.style, {
-            position: 'fixed', zIndex: '2147483646', pointerEvents: 'none',
+            position: 'fixed', zIndex: Z_LAYER, pointerEvents: 'none',
             border: `1px solid ${color}`, background: alpha, boxSizing: 'border-box', display: 'none',
         } as CSSStyleDeclaration)
         document.body.appendChild(b)
@@ -799,8 +1115,10 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     // chrome.)
     const isOwnUi = (el: Element): boolean =>
         el === hoverBox || el === panel || panel.contains(el) || el === img || el === grid ||
+        el === rulerCatcher ||
         [...wrapperLocks.values()].some(b => b === el) ||
-        [...guideEls.values()].some(g => g === el)
+        [...guideEls.values()].some(g => g === el) ||
+        [...rulerEls.values()].some(c => c === el || c.contains(el))
 
     const describeEl = (el: Element): string => {
         const r = el.getBoundingClientRect()
@@ -862,6 +1180,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             placeBox(box, el)
             wrapperLocks.set(el, box)
             attachReposition()
+            prevPick = lastPick
             lastPick = { kind: 'wrapper', el }
         }
         updatePickButton()
@@ -873,42 +1192,67 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         detachReposition()
         portalLockCount = 0
         lastPick = null
+        prevPick = null
         postToPortal({ action: 'CLEAR_LOCKS' })
         updatePickButton()
     }
 
-    // The pick target's box in page (viewport) coordinates. For portal picks we
-    // add the iframe's current position so the alignment tracks the iframe even
-    // if the wrapper layout shifted since the pick.
-    const pickTargetPageRect = (): { x: number; y: number; width: number; height: number } | null => {
-        if (!lastPick) return null
-        if (lastPick.kind === 'wrapper') {
-            if (!lastPick.el.isConnected) return null
-            const r = lastPick.el.getBoundingClientRect()
+    // A pick target's box in page (viewport) coordinates. For portal picks we
+    // add the iframe's current position so it tracks the iframe even if the
+    // wrapper layout shifted since the pick.
+    type PageRect = { x: number; y: number; width: number; height: number }
+    const pageRectOf = (pick: PickTarget | null): PageRect | null => {
+        if (!pick) return null
+        if (pick.kind === 'wrapper') {
+            if (!pick.el.isConnected) return null
+            const r = pick.el.getBoundingClientRect()
             return { x: r.left, y: r.top, width: r.width, height: r.height }
         }
         const fr = portalFrame()?.getBoundingClientRect()
         const ox = fr ? fr.left : 0
         const oy = fr ? fr.top : 0
-        const r = lastPick.rect
+        const r = pick.rect
         return { x: ox + r.x, y: oy + r.y, width: r.width, height: r.height }
     }
+    const pickTargetPageRect = () => pageRectOf(lastPick)
 
-    // Align the overlay image to the last picked element. `scaleToWidth` also
-    // scales the image (uniformly) so its width matches the element's.
-    const alignToPick = (scaleToWidth: boolean) => {
+    // Measure between the two most-recently picked elements: draw a ruler
+    // between their NEAREST points, so side-by-side boxes give the horizontal
+    // gap, stacked ones the vertical gap, and diagonal ones the corner span.
+    // (Where the boxes overlap on an axis, that end sits at the overlap centre.)
+    const nearestPoints = (a: PageRect, b: PageRect) => {
+        const aR = a.x + a.width, aB = a.y + a.height
+        const bR = b.x + b.width, bB = b.y + b.height
+        let ax: number, bx: number
+        if (aR < b.x) { ax = aR; bx = b.x }            // A entirely left of B
+        else if (bR < a.x) { ax = a.x; bx = bR }       // B entirely left of A
+        else { ax = bx = (Math.max(a.x, b.x) + Math.min(aR, bR)) / 2 } // x overlap
+        let ay: number, by: number
+        if (aB < b.y) { ay = aB; by = b.y }            // A entirely above B
+        else if (bB < a.y) { ay = a.y; by = bB }       // B entirely above A
+        else { ay = by = (Math.max(a.y, b.y) + Math.min(aB, bB)) / 2 } // y overlap
+        return { ax, ay, bx, by }
+    }
+    const measureBetweenPicks = () => {
+        const a = pageRectOf(prevPick)
+        const b = pageRectOf(lastPick)
+        if (!a || !b) { pickInfo.textContent = 'Pick two elements first (click two in pick mode)'; return }
+        const { ax, ay, bx, by } = nearestPoints(a, b)
+        addRuler(Math.round(ax), Math.round(ay), Math.round(bx), Math.round(by))
+        save()
+        pickInfo.textContent = `Measured ${Math.round(Math.hypot(bx - ax, by - ay))}px between picks`
+    }
+
+    // Align the overlay image's top-left onto the last picked element, keeping
+    // the current scale (use "fit" or the scale field to resize).
+    const alignToPick = () => {
         const rect = pickTargetPageRect()
         if (!rect) { pickInfo.textContent = 'Pick an element first (click one in pick mode)'; return }
         if (!state.src) { pickInfo.textContent = 'Load an image first'; return }
-        let scale = state.scale
-        if (scaleToWidth) {
-            if (!img.naturalWidth) { pickInfo.textContent = 'Image not loaded yet'; return }
-            scale = Number((rect.width / img.naturalWidth).toFixed(4))
-        }
         preFit = null
-        state = { ...state, x: Math.round(rect.x), y: Math.round(rect.y), scale, visible: true }
+        state = { ...state, x: Math.round(rect.x), y: Math.round(rect.y), visible: true }
         syncUi()
-        pickInfo.textContent = `Aligned to ${Math.round(rect.width)}×${Math.round(rect.height)}${scaleToWidth ? ` @ ${scale}×` : ''}`
+        pickInfo.textContent = `Aligned to ${Math.round(rect.width)}×${Math.round(rect.height)}`
     }
 
     const onPickMove = (e: PointerEvent) => {
@@ -968,7 +1312,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             pickInfo.textContent = `${d.tag ?? '?'}${id}${size}`
             // Remember a committed pick (click) inside the iframe as the align
             // target. rect is iframe-local; pickTargetPageRect() re-offsets it.
-            if (d.action === 'PICK' && d.rect) lastPick = { kind: 'portal', rect: d.rect }
+            if (d.action === 'PICK' && d.rect) { prevPick = lastPick; lastPick = { kind: 'portal', rect: d.rect } }
         }
     })
 
@@ -980,8 +1324,8 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         else if (act === 'clearUrl') { state = { ...state, src: '' }; urlInput.value = ''; syncUi(); urlInput.focus() }
         else if (act === 'paste') { void pasteFromClipboard() }
         else if (act === 'pick') { setPickActive(!pickActive) }
-        else if (act === 'alignPick') { alignToPick(false) }
-        else if (act === 'fitPick') { alignToPick(true) }
+        else if (act === 'alignPick') { alignToPick() }
+        else if (act === 'measurePicks') { measureBetweenPicks() }
         else if (act === 'collapse') { state = { ...state, collapsed: !state.collapsed }; syncUi() }
         else if (act === 'diff') { state = { ...state, diff: !state.diff }; syncUi() }
         else if (act === 'invert') { state = { ...state, invert: !state.invert }; syncUi() }
@@ -990,6 +1334,8 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         else if (act === 'addGuideV') { addGuide('x') }
         else if (act === 'addGuideH') { addGuide('y') }
         else if (act === 'clearGuides') { state = { ...state, guides: [] }; renderGuides(); save() }
+        else if (act === 'ruler') { setRulerArmed(!rulerArmed) }
+        else if (act === 'clearRulers') { state = { ...state, rulers: [] }; renderRulers(); save() }
         else if (act === 'fit') {
             if (preFit) {
                 // Second click: un-fit, restoring the size/position from before.
@@ -1052,15 +1398,21 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         // Esc exits pick mode; a second Esc (or Esc when not picking) clears
         // any locked highlights. Allowed even when a field is focused.
         if (e.key === 'Escape') {
+            if (rulerArmed) { e.preventDefault(); setRulerArmed(false); return }
             if (pickActive) { e.preventDefault(); setPickActive(false); return }
             if (totalLocks() > 0) { e.preventDefault(); clearAllLocks(); return }
         }
         const tgt = e.target as HTMLElement | null
         if (tgt && /^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName)) return
-        // Delete/Backspace removes the guide the pointer is hovering.
+        // Delete/Backspace removes the guide or ruler the pointer is hovering.
         if ((e.key === 'Delete' || e.key === 'Backspace') && hoveredGuideId) {
             e.preventDefault()
             removeGuide(hoveredGuideId)
+            return
+        }
+        if ((e.key === 'Delete' || e.key === 'Backspace') && hoveredRulerId) {
+            e.preventDefault()
+            removeRuler(hoveredRulerId)
             return
         }
         const step = e.shiftKey ? 10 : 1
@@ -1102,7 +1454,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     Object.assign(dropHint.style, {
         position: 'fixed',
         inset: '0',
-        zIndex: '2147483645',
+        zIndex: Z_DROP_HINT,
         display: 'none',
         alignItems: 'center',
         justifyContent: 'center',

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -63,12 +63,15 @@ const STORAGE_KEY = 'bring.visualDiff.wrapper.v1'
 const FIGMA_TOKEN_KEY = 'bring.visualDiff.figmaToken'
 
 // Stacking bands. The overlay's own layers (design image, grid, guides, rulers,
-// pick boxes) sit just below the very top so the dev wrapper's chrome (header +
-// sidebar) can be raised ABOVE them — that chrome is tooling, not page content,
-// so it shouldn't be covered by the design/guides/grid. The draggable control
-// panel stays at the very top, above everything. These shift the whole overlay
-// band down uniformly, preserving the layers' relative order. The matching
-// chrome z-index lives in style.css (.bar / .controls / .toggle).
+// pick boxes) sit just below the very top so the dev wrapper's interactive chrome
+// can be raised ABOVE them — those controls are tooling, not page content, so
+// they shouldn't be covered by the design/guides/grid. Only the controls that
+// need to stay usable are lifted out (the sidebar and its toggle, plus the
+// logout button); the header bar itself deliberately stays UNDER the overlay as
+// page-content backdrop. The draggable control panel stays at the very top,
+// above everything. These shift the whole overlay band down uniformly,
+// preserving the layers' relative order. The matching chrome z-index lives in
+// style.css (.controls / .toggle / .logout-btn).
 const Z_LAYER = '2147483600'
 // Above the overlay layers (so the dimmer/affordance is never hidden behind an
 // active image/grid/guides while dragging) but below the panel (kept usable).


### PR DESCRIPTION
Dev-Wrapper Tool:

1. Fixed some minor bugs with layers
2. Added: measure px distance between elements 


_____

Visual-diff overlay:
- add a "ruler" measuring tape (press-drag, draggable endpoints, Shift constrains to H/V, label offset off the line so short rulers stay legible)
- add "↔ measure" to draw a ruler between the nearest edges of the two most-recently picked elements (wrapper or portal)
- make the panel draggable by its title bar (persisted, on-screen clamped, collapses to the nearest edge); double-click title resets position
- layer the overlay (image/grid/guides/rulers) below the dev chrome so the sidebar/logout aren't covered, while still painting over the portal iframe
- slim, theme-matched scrollbar for the sidebar; remove the unused fit→pick

Wrapper controls:
- replace "Start disconnected" with "Start connected" (mock pre-connects with the default address; external providers connect on iframe load if possible)
- drop the Auto-respond LOGIN/SIGN_MESSAGE toggles (always auto-respond now)
- give the top bar a distinct background so it reads as its own element