### PR TITLE
feat: add retailer initials fallback to cashback history icons

### DIFF
--- a/src/components/HistoryItem/HistoryItem.mobile.tsx
+++ b/src/components/HistoryItem/HistoryItem.mobile.tsx
@@ -11,7 +11,7 @@ import styles from './styles.mobile.module.css'
 
 const HistoryItem: FC<HistoryItemProps> = (props) => {
     const { row, isOpen } = props
-    const { panelId, buttonId, imgFailed, onImgError, expandable, handleClick } =
+    const { panelId, buttonId, imgFailed, fallbackLogo, onImgError, expandable, handleClick } =
         useHistoryItem(props)
 
     return (
@@ -30,8 +30,8 @@ const HistoryItem: FC<HistoryItemProps> = (props) => {
                 disabled={!expandable}
             >
                 <span
-                    className={`${styles.avatar} ${row.isClaim ? styles.avatarClaim : ''}`}
-                    style={!row.isClaim ? { background: row.iconBg || '#FFFFFF' } : undefined}
+                    className={`${styles.avatar} ${row.isClaim ? styles.avatarClaim : ''} ${fallbackLogo ? styles.avatarHasFallback : ''}`}
+                    style={!row.isClaim && !fallbackLogo ? { background: row.iconBg || '#FFFFFF' } : undefined}
                     aria-hidden="true"
                 >
                     {row.isClaim ? (
@@ -43,7 +43,13 @@ const HistoryItem: FC<HistoryItemProps> = (props) => {
                             alt=""
                             onError={onImgError}
                         />
-                    ) : null}
+                    ) : (
+                        <span
+                            className={`${styles.avatarFallback} ${fallbackLogo.length === 2 ? styles.avatarFallbackTwo : ''}`}
+                        >
+                            {fallbackLogo}
+                        </span>
+                    )}
                 </span>
                 <span className={styles.body}>
                     <span className={styles.name}>{row.retailerName}</span>

--- a/src/components/HistoryItem/styles.mobile.module.css
+++ b/src/components/HistoryItem/styles.mobile.module.css
@@ -71,6 +71,24 @@
     height: 57.14%;
 }
 
+/* Initials fallback when a retailer logo is missing or fails — mirrors RetailerCard,
+   including its light icon background so the initials stay readable on dark themes. */
+.avatarHasFallback {
+    background: var(--retailer-icon-bg, #FFFFFF);
+}
+
+.avatarFallback {
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 1;
+    text-transform: uppercase;
+    color: var(--retailer-fallback-f-c);
+}
+
+.avatarFallbackTwo {
+    font-size: 14px;
+}
+
 /* Body — name + date stacked. */
 .body {
     display: flex;

--- a/src/components/HistoryItem/useHistoryItem.ts
+++ b/src/components/HistoryItem/useHistoryItem.ts
@@ -4,6 +4,7 @@
  */
 import { useState } from 'react'
 import { MobileHistoryRow } from '../../hooks/useHistory'
+import { getInitials } from '../../utils/getInitials'
 
 export interface HistoryItemProps {
     row: MobileHistoryRow
@@ -18,6 +19,10 @@ export const useHistoryItem = ({ row, onToggle }: HistoryItemProps) => {
 
     const expandable = row.description.some((d) => d[0] || d[1])
 
+    // Initials fallback (like RetailerCard) when the logo is missing or fails.
+    const fallbackLogo =
+        !row.isClaim && (imgFailed || !row.iconSrc) ? getInitials(row.retailerName) : ''
+
     const handleClick = () => {
         if (expandable) onToggle()
     }
@@ -26,6 +31,7 @@ export const useHistoryItem = ({ row, onToggle }: HistoryItemProps) => {
         panelId,
         buttonId,
         imgFailed,
+        fallbackLogo,
         onImgError: () => setImgFailed(true),
         expandable,
         handleClick,

--- a/src/pages/History/History.oldMobile.tsx
+++ b/src/pages/History/History.oldMobile.tsx
@@ -58,9 +58,14 @@ const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, 
                                 className={styles.img}
                                 src={imgSrc}
                                 alt="logo"
-                                onError={imgSrcFallback ? (e) => {
-                                    if (e.currentTarget.src !== imgSrcFallback) e.currentTarget.src = imgSrcFallback
-                                } : () => setFallbackLogo(getInitials(retailerName))}
+                                onError={(e) => {
+                                    const img = e.currentTarget
+                                    if (imgSrcFallback && img.getAttribute('src') !== imgSrcFallback) {
+                                        img.src = imgSrcFallback
+                                        return
+                                    }
+                                    setFallbackLogo(getInitials(retailerName))
+                                }}
                             />
                         }
                     </div>

--- a/src/pages/History/History.oldMobile.tsx
+++ b/src/pages/History/History.oldMobile.tsx
@@ -9,6 +9,7 @@ import { useAnalytics } from '../../hooks/useAnalytics'
 import { useTranslation } from 'react-i18next'
 import { useWalletAddress } from '../../hooks/useWalletAddress'
 import Icon from '../../components/Icon/Icon'
+import { getInitials } from '../../utils/getInitials'
 
 interface HistoryMobile {
     status: string
@@ -37,6 +38,7 @@ interface ClaimsRes {
 }
 
 const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, totalEstimatedUsd, imgBg, retailerName = 'Total claims', description }: RowProps): JSX.Element => {
+    const [fallbackLogo, setFallbackLogo] = useState('')
     return (
         <div id="history-mobile-row" className={`${styles.collapsible} ${isActive ? styles.collapsible_open : ''}`}>
             <div
@@ -45,18 +47,22 @@ const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, 
             >
                 <div className={styles.name_container}>
                     <div
-                        className={styles.img_container}
-                        style={status.toLowerCase() === 'claimed' ? {} : { background: imgBg || 'white' }}
+                        className={`${styles.img_container} ${fallbackLogo ? styles.img_container_fallback : ''}`}
+                        style={fallbackLogo || status.toLowerCase() === 'claimed' ? {} : { background: imgBg || 'white' }}
                     >
-                        <img
-                            style={{ height: `${status.toLowerCase() === 'claimed' ? 'auto' : '100%'}` }}
-                            className={styles.img}
-                            src={imgSrc}
-                            alt="logo"
-                            onError={imgSrcFallback ? (e) => {
-                                if (e.currentTarget.src !== imgSrcFallback) e.currentTarget.src = imgSrcFallback
-                            } : undefined}
-                        />
+                        {fallbackLogo ?
+                            <div className={`${styles.fallback_logo} ${fallbackLogo.length === 2 ? styles.fallback_logo_two_letters : ''}`}>{fallbackLogo}</div>
+                            :
+                            <img
+                                style={{ height: `${status.toLowerCase() === 'claimed' ? 'auto' : '100%'}` }}
+                                className={styles.img}
+                                src={imgSrc}
+                                alt="logo"
+                                onError={imgSrcFallback ? (e) => {
+                                    if (e.currentTarget.src !== imgSrcFallback) e.currentTarget.src = imgSrcFallback
+                                } : () => setFallbackLogo(getInitials(retailerName))}
+                            />
+                        }
                     </div>
                     <span className={`${styles.purchase_name} ${retailerName.length > 20 ? '' : styles.nowrap}`}>{retailerName}</span>
                 </div>

--- a/src/pages/History/History.tsx
+++ b/src/pages/History/History.tsx
@@ -58,9 +58,14 @@ const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, 
                                 className={styles.img}
                                 src={imgSrc}
                                 alt="logo"
-                                onError={imgSrcFallback ? (e) => {
-                                    if (e.currentTarget.src !== imgSrcFallback) e.currentTarget.src = imgSrcFallback
-                                } : () => setFallbackLogo(getInitials(retailerName))}
+                                onError={(e) => {
+                                    const img = e.currentTarget
+                                    if (imgSrcFallback && img.getAttribute('src') !== imgSrcFallback) {
+                                        img.src = imgSrcFallback
+                                        return
+                                    }
+                                    setFallbackLogo(getInitials(retailerName))
+                                }}
                             />
                         }
                     </div>

--- a/src/pages/History/History.tsx
+++ b/src/pages/History/History.tsx
@@ -9,6 +9,7 @@ import { useAnalytics } from '../../hooks/useAnalytics'
 import { useTranslation } from 'react-i18next'
 import { useWalletAddress } from '../../hooks/useWalletAddress'
 import Icon from '../../components/Icon/Icon'
+import { getInitials } from '../../utils/getInitials'
 
 interface HistoryDesktop {
     status: string
@@ -37,6 +38,7 @@ interface ClaimsRes {
 }
 
 const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, totalEstimatedUsd, imgBg, retailerName = 'Total claims', description }: RowProps): JSX.Element => {
+    const [fallbackLogo, setFallbackLogo] = useState('')
     return (
         <div id="history-desktop-row" className={`${styles.collapsible} ${isActive ? styles.collapsible_open : ''}`}>
             <div
@@ -45,18 +47,22 @@ const Row = ({ isActive, toggleFn, imgSrc, imgSrcFallback, status, tokenAmount, 
             >
                 <div className={styles.name_container}>
                     <div
-                        className={styles.img_container}
-                        style={status.toLowerCase() === 'claimed' ? {} : { background: imgBg || 'white' }}
+                        className={`${styles.img_container} ${fallbackLogo ? styles.img_container_fallback : ''}`}
+                        style={fallbackLogo || status.toLowerCase() === 'claimed' ? {} : { background: imgBg || 'white' }}
                     >
-                        <img
-                            style={{ height: `${status.toLowerCase() === 'claimed' ? 'auto' : '100%'}` }}
-                            className={styles.img}
-                            src={imgSrc}
-                            alt="logo"
-                            onError={imgSrcFallback ? (e) => {
-                                if (e.currentTarget.src !== imgSrcFallback) e.currentTarget.src = imgSrcFallback
-                            } : undefined}
-                        />
+                        {fallbackLogo ?
+                            <div className={`${styles.fallback_logo} ${fallbackLogo.length === 2 ? styles.fallback_logo_two_letters : ''}`}>{fallbackLogo}</div>
+                            :
+                            <img
+                                style={{ height: `${status.toLowerCase() === 'claimed' ? 'auto' : '100%'}` }}
+                                className={styles.img}
+                                src={imgSrc}
+                                alt="logo"
+                                onError={imgSrcFallback ? (e) => {
+                                    if (e.currentTarget.src !== imgSrcFallback) e.currentTarget.src = imgSrcFallback
+                                } : () => setFallbackLogo(getInitials(retailerName))}
+                            />
+                        }
                     </div>
                     <span className={styles.purchase_name}>{retailerName}</span>
                 </div>

--- a/src/pages/History/styles.module.css
+++ b/src/pages/History/styles.module.css
@@ -100,6 +100,31 @@
     max-width: 100%;
 }
 
+/* No container background behind the initials - it peeks out as a ring. */
+.img_container_fallback {
+    background: none;
+}
+
+.fallback_logo {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+    border-radius: 50%;
+    text-align: center;
+    text-transform: uppercase;
+    background: var(--retailer-logo-fallback-bg, var(--retailer-card-img-border-c));
+    color: var(--retailer-logo-fallback-f-c, white);
+    font-weight: var(--retailer-logo-fallback-f-w, 700);
+    font-size: 21px;
+}
+
+.fallback_logo_two_letters {
+    font-size: 26px;
+    background: var(--retailer-logo-fallback-bg, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
+}
+
 .details_btn {
     display: flex;
     justify-content: center;

--- a/src/pages/History/styles.oldMobile.module.css
+++ b/src/pages/History/styles.oldMobile.module.css
@@ -88,6 +88,31 @@
     max-width: 100%;
 }
 
+/* No container background behind the initials - it peeks out as a ring. */
+.img_container_fallback {
+    background: none;
+}
+
+.fallback_logo {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+    border-radius: 50%;
+    text-align: center;
+    text-transform: uppercase;
+    background: var(--retailer-logo-fallback-bg, var(--retailer-card-img-border-c));
+    color: var(--retailer-logo-fallback-f-c, white);
+    font-weight: var(--retailer-logo-fallback-f-w, 700);
+    font-size: 15px;
+}
+
+.fallback_logo_two_letters {
+    font-size: 19px;
+    background: var(--retailer-logo-fallback-bg, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
+}
+
 .details_btn {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/455
________

Reuse the RetailerCard initials fallback (getInitials) in all three history surfaces: desktop table, legacy responsive mobile, and the mobile portal. When a retailer icon is missing or fails to load, show themed initials instead of a broken image or empty circle.

- Desktop & oldMobile: initials circle styled via the existing --retailer-logo-fallback-* theme vars; container background removed behind the fallback so it doesn't peek out as a ring
- Mobile portal: avatar switches to --retailer-icon-bg when showing initials so they stay readable on dark themes; also covers rows with no iconSrc at all