### PR TITLE
feat: inject retailer cashback rate into terms markdown

### DIFF
--- a/src/components/CardsList/useCardsList.ts
+++ b/src/components/CardsList/useCardsList.ts
@@ -9,6 +9,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useRouteLoaderData } from 'react-router-dom'
 import activate from '../../api/activate'
 import fetchTerms from '../../utils/fetchTerms'
+import formatCashback from '../../utils/formatCashback'
+import injectCashback from '../../utils/injectCashback'
 import { useWalletAddress } from '../../hooks/useWalletAddress'
 import { useAnalytics } from '../../hooks/useAnalytics'
 import type { RetailersMetadata } from '../../hooks/useRetailers'
@@ -104,7 +106,8 @@ export const useCardsList = ({
         Promise.all(fetches)
             .then(([retailerTerms, campaignTerms]) => {
                 if (controller.signal.aborted) return
-                setActiveTerms(campaignTerms || topGeneralTerms + retailerTerms + generalTerms)
+                const cashback = formatCashback(activeRetailer.maxCashback, activeRetailer.cashbackSymbol, activeRetailer.cashbackCurrency)
+                setActiveTerms(injectCashback(campaignTerms || topGeneralTerms + retailerTerms + generalTerms, cashback))
             })
             .catch((err) => {
                 if (!controller.signal.aborted) console.error('Failed to fetch retailer terms', err)

--- a/src/components/RetailerCard/RetailerCard.tsx
+++ b/src/components/RetailerCard/RetailerCard.tsx
@@ -8,6 +8,7 @@ import { useAnalytics } from '../../hooks/useAnalytics'
 import { useWalletAddress } from '../../hooks/useWalletAddress'
 import LoginModal from '../Modals/LoginModal/LoginModal'
 import fetchTerms from '../../utils/fetchTerms'
+import injectCashback from '../../utils/injectCashback'
 import { getInitials } from '../../utils/getInitials'
 
 const isBigCashback = (symbol: string, amount: number) => {
@@ -135,7 +136,7 @@ const RetailerCard = ({
 
         Promise.all(fetches)
             .then(([retailerTerms, campaignTerms]) => {
-                setTerms(campaignTerms || topGeneralTerms + retailerTerms + generalTerms)
+                setTerms(injectCashback(campaignTerms || topGeneralTerms + retailerTerms + generalTerms, cashback))
             })
             .catch(console.error)
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/utils/injectCashback.ts
+++ b/src/utils/injectCashback.ts
@@ -1,0 +1,11 @@
+/**
+ * Replaces {{cashback}} marks in terms markdown with the retailer's formatted
+ * cashback rate, so the mass-uploaded general MD can show per-retailer values
+ * without manual edits. Markdown without the mark passes through unchanged.
+ */
+const CASHBACK_MARK = /\{\{\s*cashback\s*\}\}/gi
+
+const injectCashback = (markdown: string, cashback: string): string =>
+    markdown.replace(CASHBACK_MARK, cashback)
+
+export default injectCashback


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/131
_____
Add injectCashback util that replaces {{cashback}} placeholders in terms MD with the retailer's formatted cashback value, and apply it when setting terms in useCardsList and RetailerCard.