### PR TITLE
fix(retailers): refetch the list when the wallet connects

### DIFF
--- a/src/hooks/useRetailers.ts
+++ b/src/hooks/useRetailers.ts
@@ -35,7 +35,9 @@ export const useRetailers = (
     const country = searchParams.get('country')?.toUpperCase()
 
     return useInfiniteQuery({
-        queryKey: ['retailers', category, search],
+        // walletAddress is part of the key because the backend orders the list by the caller's
+        // engagement history — connecting a wallet must refetch rather than reuse the anonymous list.
+        queryKey: ['retailers', category, search, walletAddress],
         queryFn: async ({ pageParam }) => {
             const options: Parameters<typeof fetchRetailers>[0] = {
                 type: 'all',

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -60,7 +60,10 @@ const Home = () => {
         isLoading: isLoadingRetailers,
         isSuccess: isRetailersSuccess,
     } = useInfiniteQuery({
-        queryKey: ["retailers", category, search],
+        // walletAddress is part of the key because the backend orders the list by the caller's
+        // engagement history — connecting a wallet must refetch rather than reuse the anonymous list.
+        // Must stay identical to the key in hooks/useRetailers.ts so both surfaces share one cache.
+        queryKey: ["retailers", category, search, walletAddress],
         queryFn: async ({ pageParam }) => {
             const options: Parameters<typeof fetchRetailers>[0] = {
                 type: "all",


### PR DESCRIPTION
Portal Order
https://github.com/Bring-Web3-LTD/TODO/issues/487

The backend orders /retailers by the caller's engagement history, so the list a connected user should see differs from the anonymous one. Both retailers queries passed walletAddress in the request body but left it out of the React Query key, so connecting a wallet reused the cached anonymous list and the personalized order never appeared.

Add walletAddress to the key in both the mobile hook and desktop Home, keeping the two identical so they continue to share one cache entry. React Query refetches on key change, so no manual invalidation is needed.