### PR TITLE
feat(mobile): Coupons tab with partner iframe and connect promo

### DIFF
--- a/dev-wrapper/.env.example
+++ b/dev-wrapper/.env.example
@@ -45,6 +45,11 @@ VITE_PORTAL_WALLET=0x1111111111111111111111111111111111111111
 # Valid values: "dark", "light", or "unset" (omit / empty = let the portal/API decide).
 VITE_PORTAL_THEME=unset
 
+# Default view mode for the dev wrapper's "View mode" selector on first load.
+# Valid values: "desktop", "mobile", "responsive" (omit / empty = desktop).
+# A mode picked in the UI is saved to localStorage and wins over this default.
+VITE_PORTAL_VIEW_MODE=desktop
+
 # Figma personal access token (server-side only, NOT exposed to the browser).
 # Used by the dev-wrapper's /__figma-image proxy so the visual-diff overlay can
 # load a frame straight from a Figma link. Create one at

--- a/dev-wrapper/README.md
+++ b/dev-wrapper/README.md
@@ -8,6 +8,11 @@ implement.
 ## What it does
 
 1. Reads `theme`, `walletAddress`, `extensionId` from the controls.
+   When a device preset is active (Mobile/Responsive view modes) the payload
+   also carries `devicePlatform: 'ios' | 'android'`, so the backend can bake
+   an explicit platform into platform-sensitive iframe URLs it builds (e.g.
+   AppCard's `platform` param in `couponsIframeSrc`) instead of those pages
+   UA-sniffing the desktop browser. Ignored until the backend supports it.
 2. Calls `POST $VITE_PORTAL_API` (the dev `check/portal` endpoint) with
    `x-api-key: $VITE_PORTAL_API_KEY`. The URL and key actually used are
    chosen by the **Wallet provider** selector — see

--- a/dev-wrapper/README.md
+++ b/dev-wrapper/README.md
@@ -17,7 +17,7 @@ implement.
    `x-api-key: $VITE_PORTAL_API_KEY`. The URL and key actually used are
    chosen by the **Wallet provider** selector — see
    [Per-provider API](#per-provider-api). The active API path (stage) is
-   shown read-only above the Inputs.
+   shown read-only at the top of the sidebar.
 3. On the first response, sets the iframe `src` from `portalUrl` (the JWT is
    already embedded in its query string — no `postMessage` needed). The
    legacy `iframeUrl` field is ignored.
@@ -93,26 +93,46 @@ Open <http://localhost:5174>.
 
 ## UI
 
+- **Header — view toolbar** — centred display controls: view mode
+  (Desktop / Mobile / Responsive), device preset + rotate, stage width×height,
+  and the wrapper-background swatch / hatch / reset. Controls that don't apply
+  to the current mode stay visible but grayed out (e.g. everything but the
+  mode select in Desktop, where the iframe covers the whole frame).
 - **Header / wallet button** — top-right. Click to connect (sends
   `SESSION_UPDATE`) or, when connected, click the short `0xab12…cdef`
   pill to disconnect.
-- **Sidebar — Wallet provider** — selects which wallet adapter to simulate and
-  which API URL/key to use (see [Per-provider API](#per-provider-api)).
-  Switching it starts a brand-new portal session and reloads the iframe.
-- **Sidebar — API path** — read-only text above the Inputs showing the active
+- **Sidebar — API path** — read-only text at the top showing the active
   API stage. It's set from the env on deploy, not editable in the UI.
-- **Sidebar — Inputs** — theme / wallet / extension ID + Refresh. Changing any
-  value re-calls the API and posts the new token to the iframe.
-- **Sidebar — Mock wallet SDK** — toggles for *Start disconnected*,
-  *Auto-respond to LOGIN*, *Auto-respond to SIGN_MESSAGE*, plus manual
-  *Send connect* / *Abort sign* buttons.
-- **Sidebar — Event log** — colour-coded stream of all messages
-  (`←` inbound, `→` outbound, `✗` error, `·` info) with timestamps and JSON
-  payloads.
-- **Sidebar — Last API response** (collapsed by default) — read-only view of
-  the last `portalUrl` and decoded JWT payload.
+- **Sidebar — Bootstrap** — the partner-page parameters of the
+  `check/portal` call: theme, extension ID, style-as override.
+  Changing any value re-calls the API and posts the new token to the iframe.
+- **Sidebar — Wallet** — the simulated end user: wallet provider (also picks
+  which API URL/key to use — see [Per-provider API](#per-provider-api);
+  switching starts a brand-new portal session and reloads the iframe), wallet
+  address, *Start connected* with a *Send connect* link beside it (manually
+  runs the connect flow), and a
+  collapsed *Wallet identity* drawer simulating integrations that pass the
+  optional wallet name/emoji in the bootstrap (they end up in the JWT and on
+  the claim screen). *Start with this identity* (available once a value is
+  set) persists them so the first bootstrap after a page reload already
+  includes them; a green dot on the drawer head marks a set identity even
+  while collapsed.
+- **Sidebar — refresh icon (⟳)** — next to the API path: manually re-runs the
+  bootstrap call with everything currently set (Bootstrap params and wallet
+  state) and pushes the fresh token to the portal. Rarely needed — every
+  input re-bootstraps on change — but handy to retry after an API error.
+- **Sidebar — Event log** (collapsible) — colour-coded stream of the bridge
+  protocol messages (`←` inbound, `→` outbound, `✗` error, `·` info) with
+  timestamps and JSON payloads.
+- **Sidebar — Window messages** (collapsed by default) — raw, unfiltered
+  recorder of every `message` event the wrapper page receives (with source
+  window + origin) plus everything it posts to the portal. Use it to debug the
+  postMessage protocol itself; the Event log above shows only the curated
+  bridge traffic.
+- **Sidebar — Last API response / Decoded JWT** (collapsed by default) —
+  read-only view of the last `portalUrl`, raw token, and decoded JWT payload.
 - **Toggle button** on the sidebar edge collapses the controls to give the
-  iframe full width.
+  iframe full width (the header view toolbar stays available).
 
 ## Visual diff overlay
 

--- a/dev-wrapper/index.html
+++ b/dev-wrapper/index.html
@@ -73,6 +73,15 @@
                         </select>
                     </label>
 
+                    <div class="device-row" id="deviceRow" hidden>
+                        <label>
+                            <span>Device</span>
+                            <select id="devicePreset"></select>
+                        </label>
+                        <button id="rotateDevice" type="button" class="secondary rotate"
+                            title="Rotate (swap width and height)">&#10561;</button>
+                    </div>
+
                     <div class="responsive-size" id="responsiveSize" hidden>
                         <label>
                             <span>Width (px)</span>

--- a/dev-wrapper/index.html
+++ b/dev-wrapper/index.html
@@ -17,12 +17,35 @@
                     <code>POST /v1/extension/check/portal</code> bootstrap call.
                 </p>
             </div>
-            <button id="walletBtn" type="button" class="wallet-btn" data-state="disconnected">
-                Connect wallet
-            </button>
-            <button id="logoutBtn" type="button" class="logout-btn" title="Clear CloudFront basic-auth credentials" hidden>
-                Log out
-            </button>
+            <div class="view-toolbar">
+                <select id="viewMode" title="View mode">
+                    <option value="desktop">Desktop</option>
+                    <option value="mobile">Mobile</option>
+                    <option value="responsive">Responsive</option>
+                </select>
+                <div class="tb-group" id="deviceRow">
+                    <select id="devicePreset" title="Device preset (Mobile/Responsive modes)"></select>
+                    <button id="rotateDevice" type="button" title="Rotate (swap width and height)">&#10561;</button>
+                </div>
+                <div class="tb-group" id="responsiveSize">
+                    <input id="responsiveWidth" type="number" min="200" max="3840" step="1" title="Stage width (px, Responsive mode)" />
+                    <span class="tb-x">&#215;</span>
+                    <input id="responsiveHeight" type="number" min="200" max="2400" step="1" title="Stage height (px, Responsive mode)" />
+                </div>
+                <div class="tb-group" id="pageBgRow">
+                    <input id="pageBgColor" type="color" title="Colour of the wrapper area around the portal stage (Mobile/Responsive modes — in Desktop the portal fills the frame)" />
+                    <button id="pageBgHatch" type="button" title="Toggle diagonal hatching on the area around the stage">&#9640;</button>
+                    <button id="pageBgReset" type="button" title="Reset to the default colour with hatching">&#8634;</button>
+                </div>
+            </div>
+            <div class="bar-actions">
+                <button id="walletBtn" type="button" class="wallet-btn" data-state="disconnected">
+                    Connect wallet
+                </button>
+                <button id="logoutBtn" type="button" class="logout-btn" title="Clear CloudFront basic-auth credentials" hidden>
+                    Log out
+                </button>
+            </div>
         </header>
 
         <main class="layout" id="layout">
@@ -30,10 +53,20 @@
                 <span class="toggle-icon" aria-hidden="true">‹</span>
             </button>
             <aside class="controls">
-                <p class="api-info">API path: <code id="apiStageInfo">—</code></p>
+                <div class="api-row">
+                    <p class="api-info">API path: <code id="apiStageInfo">—</code></p>
+                    <button id="refresh" type="button" class="secondary refresh-icon" aria-label="Refresh"
+                        title="Re-run the check/portal bootstrap with the current params and wallet state">
+                        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <polyline points="23 4 23 10 17 10" />
+                            <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                        </svg>
+                    </button>
+                </div>
 
                 <fieldset>
-                    <legend>Inputs</legend>
+                    <legend>Bootstrap</legend>
 
                     <label>
                         <span>Theme</span>
@@ -45,53 +78,9 @@
                     </label>
 
                     <label>
-                        <span>Wallet address</span>
-                        <input id="wallet" type="text" placeholder="0x… (leave empty for null)" />
-                    </label>
-
-                    <label>
                         <span>Extension ID</span>
                         <input id="extensionId" type="text" />
                     </label>
-
-                    <label>
-                        <span>Wallet name</span>
-                        <input id="walletName" type="text" placeholder="(optional, e.g. WalletName)" />
-                    </label>
-
-                    <label>
-                        <span>Wallet emoji URL</span>
-                        <input id="walletEmoji" type="text" placeholder="(optional, asset URL)" />
-                    </label>
-
-                    <label>
-                        <span>View mode</span>
-                        <select id="viewMode">
-                            <option value="desktop">Desktop</option>
-                            <option value="mobile">Mobile</option>
-                            <option value="responsive">Responsive</option>
-                        </select>
-                    </label>
-
-                    <div class="device-row" id="deviceRow" hidden>
-                        <label>
-                            <span>Device</span>
-                            <select id="devicePreset"></select>
-                        </label>
-                        <button id="rotateDevice" type="button" class="secondary rotate"
-                            title="Rotate (swap width and height)">&#10561;</button>
-                    </div>
-
-                    <div class="responsive-size" id="responsiveSize" hidden>
-                        <label>
-                            <span>Width (px)</span>
-                            <input id="responsiveWidth" type="number" min="200" max="3840" step="1" />
-                        </label>
-                        <label>
-                            <span>Height (px)</span>
-                            <input id="responsiveHeight" type="number" min="200" max="2400" step="1" />
-                        </label>
-                    </div>
 
                     <label>
                         <span>Style as</span>
@@ -100,12 +89,10 @@
                             <option value="DEFAULT">DEFAULT</option>
                         </select>
                     </label>
-
-                    <button id="refresh" type="button">Refresh</button>
                 </fieldset>
 
                 <fieldset>
-                    <legend>Mock wallet SDK</legend>
+                    <legend>Wallet</legend>
                     <label>
                         <span>Wallet provider</span>
                         <select id="walletProvider">
@@ -119,21 +106,47 @@
                             <option value="ready">Ready / Argent (Starknet, connect only)</option>
                         </select>
                     </label>
-                    <label class="row">
-                        <input id="startConnected" type="checkbox" />
-                        <span>Start connected</span>
+                    <label>
+                        <span>Wallet address</span>
+                        <input id="wallet" type="text" placeholder="0x… (leave empty for null)" />
                     </label>
-                    <div class="btn-row">
-                        <button id="manualConnect" type="button" class="secondary">Send connect</button>
-                        <button id="manualAbort" type="button" class="secondary">Abort sign</button>
+                    <div class="row-split">
+                        <label class="row">
+                            <input id="startConnected" type="checkbox" />
+                            <span>Start connected</span>
+                        </label>
+                        <button id="manualConnect" type="button" class="link-btn"
+                            title="Manually run the wallet connect flow and push the session to the portal">Send connect</button>
                     </div>
+                    <details class="debug">
+                        <summary>Wallet identity (optional)<span id="identityDot" class="identity-dot"
+                                title="A wallet identity value is set" hidden></span></summary>
+                        <label>
+                            <span>Wallet name</span>
+                            <input id="walletName" type="text" placeholder="(optional, e.g. WalletName)" />
+                        </label>
+                        <label>
+                            <span>Wallet emoji URL</span>
+                            <input id="walletEmoji" type="text" placeholder="(optional, asset URL)" />
+                        </label>
+                        <label class="row">
+                            <input id="identityStart" type="checkbox" />
+                            <span>Start with this identity</span>
+                        </label>
+                    </details>
                 </fieldset>
 
-                <fieldset>
-                    <legend>Event log</legend>
+                <details class="debug" open>
+                    <summary>Event log<span id="logCount" class="msg-count">0</span></summary>
                     <div id="log" class="log"></div>
                     <button id="clearLog" type="button" class="secondary">Clear</button>
-                </fieldset>
+                </details>
+
+                <details class="debug">
+                    <summary>Window messages<span id="msgCount" class="msg-count">0</span></summary>
+                    <div id="msgLog" class="log"></div>
+                    <button id="clearMsgLog" type="button" class="secondary">Clear</button>
+                </details>
 
                 <details class="debug">
                     <summary>Last API response</summary>

--- a/dev-wrapper/main.ts
+++ b/dev-wrapper/main.ts
@@ -128,7 +128,6 @@ toggleBtn.addEventListener('click', () => {
 // iframe.
 const VIEW_MODE_KEY = 'bring-dev-wrapper:view-mode'
 const RESPONSIVE_SIZE_KEY = 'bring-dev-wrapper:responsive-size'
-const responsiveSizeEl = $<HTMLDivElement>('responsiveSize')
 const responsiveWidthEl = $<HTMLInputElement>('responsiveWidth')
 const responsiveHeightEl = $<HTMLInputElement>('responsiveHeight')
 
@@ -172,7 +171,6 @@ const DEVICES: { key: string; label: string; w: number; h: number; group: string
 ]
 const DEVICE_KEY = 'bring-dev-wrapper:device'
 const DEVICE_LANDSCAPE_KEY = 'bring-dev-wrapper:device-landscape'
-const deviceRowEl = $<HTMLDivElement>('deviceRow')
 const deviceEl = $<HTMLSelectElement>('devicePreset')
 const rotateBtn = $<HTMLButtonElement>('rotateDevice')
 
@@ -202,11 +200,14 @@ const savedDevice = localStorage.getItem(DEVICE_KEY) || ''
 deviceEl.value = DEVICES.some(d => d.key === savedDevice) ? savedDevice : ''
 
 const applyDevice = (mode: string) => {
-    deviceRowEl.hidden = mode !== 'mobile' && mode !== 'responsive'
+    // Toolbar controls stay visible in every mode and gray out when inactive,
+    // so the header doesn't reflow as the mode changes.
+    const framed = mode === 'mobile' || mode === 'responsive'
+    deviceEl.disabled = !framed
     const device = DEVICES.find(d => d.key === deviceEl.value)
     // In Mobile mode with no device there's nothing to rotate (fixed 360px
     // column); in Responsive mode rotate always works (swaps custom size too).
-    rotateBtn.disabled = !device && mode === 'mobile'
+    rotateBtn.disabled = !framed || (!device && mode === 'mobile')
     frameEl.classList.toggle('has-device', Boolean(device) && mode === 'mobile')
     if (!device) return
     const w = deviceLandscape ? device.h : device.w
@@ -245,6 +246,9 @@ const clearDeviceSelection = () => {
 }
 
 deviceEl.addEventListener('change', () => {
+    // Drop focus once picked, so the toolbar doesn't keep a focus ring and
+    // stray arrow keys can't re-trigger a device change.
+    deviceEl.blur()
     localStorage.setItem(DEVICE_KEY, deviceEl.value)
     applyDevice(viewModeEl.value)
     // Re-bootstrap so the portal re-evaluates useMobilePortal at the new width.
@@ -267,10 +271,78 @@ rotateBtn.addEventListener('click', () => {
     void refresh()
 })
 
+// Stage background: colour + hatch of the #frame surround around the portal
+// stage. Grayed out in Desktop mode — the iframe covers the frame edge-to-
+// edge there, so there's nothing to colour. Nothing stored = default
+// colour WITH hatching; the ↺ button returns to that default. (Same storage
+// key as when this control lived in the visual-diff panel, so an already-
+// picked colour carries over.)
+const PAGE_BG_KEY = 'bring.visualDiff.pageBg'
+const PAGE_BG_DEFAULT = '#0f0f1a'
+const pageBgColorEl = $<HTMLInputElement>('pageBgColor')
+const pageBgHatchBtn = $<HTMLButtonElement>('pageBgHatch')
+const pageBgResetBtn = $<HTMLButtonElement>('pageBgReset')
+
+type PageBg = { color: string; hatch: boolean }
+let pageBg: PageBg | null = (() => {
+    try {
+        const parsed = JSON.parse(localStorage.getItem(PAGE_BG_KEY) || '') as Partial<PageBg>
+        if (typeof parsed.color === 'string') return { color: parsed.color, hatch: !!parsed.hatch }
+    } catch { /* nothing stored / corrupt — use the default */ }
+    return null
+})()
+const savePageBg = () => {
+    if (pageBg) localStorage.setItem(PAGE_BG_KEY, JSON.stringify(pageBg))
+    else localStorage.removeItem(PAGE_BG_KEY)
+}
+// `live` paints a not-yet-committed picker value while the colour wheel is
+// open. Inline styles override the `.frame.*` stylesheet backgrounds. The
+// hatch stripe tint flips with the colour's luminance so the texture stays
+// visible on both dark and light picks.
+const applyPageBg = (live?: string) => {
+    const active = live !== undefined
+        ? { color: live, hatch: pageBg?.hatch ?? true }
+        : pageBg ?? { color: PAGE_BG_DEFAULT, hatch: true }
+    pageBgColorEl.value = active.color
+    pageBgHatchBtn.classList.toggle('active', active.hatch)
+    const hex = /^#[0-9a-fA-F]{6}$/.test(active.color) ? active.color : PAGE_BG_DEFAULT
+    const [r, g, b] = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16))
+    const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+    const stripe = luminance > 0.55 ? 'rgba(0,0,0,0.07)' : 'rgba(255,255,255,0.05)'
+    frameEl.style.background = hex
+    frameEl.style.backgroundImage = active.hatch
+        ? `repeating-linear-gradient(45deg, ${stripe} 0 8px, transparent 8px 16px)`
+        : 'none'
+}
+// Repaint live while the picker is open; persist only on commit, so dragging
+// through the colour wheel doesn't write on every frame.
+pageBgColorEl.addEventListener('input', () => applyPageBg(pageBgColorEl.value))
+pageBgColorEl.addEventListener('change', () => {
+    pageBg = { color: pageBgColorEl.value, hatch: pageBg?.hatch ?? true }
+    savePageBg()
+    applyPageBg()
+})
+pageBgHatchBtn.addEventListener('click', () => {
+    pageBg = { color: pageBgColorEl.value, hatch: !(pageBg?.hatch ?? true) }
+    savePageBg()
+    applyPageBg()
+})
+pageBgResetBtn.addEventListener('click', () => {
+    pageBg = null
+    savePageBg()
+    applyPageBg()
+})
+applyPageBg()
+
 const applyViewMode = (mode: string) => {
     frameEl.classList.toggle('mobile', mode === 'mobile')
     frameEl.classList.toggle('responsive', mode === 'responsive')
-    responsiveSizeEl.hidden = mode !== 'responsive'
+    const framed = mode === 'mobile' || mode === 'responsive'
+    responsiveWidthEl.disabled = mode !== 'responsive'
+    responsiveHeightEl.disabled = mode !== 'responsive'
+    pageBgColorEl.disabled = !framed
+    pageBgHatchBtn.disabled = !framed
+    pageBgResetBtn.disabled = !framed
     applyDevice(mode)
 }
 const savedViewMode = localStorage.getItem(VIEW_MODE_KEY)
@@ -278,6 +350,8 @@ const savedViewMode = localStorage.getItem(VIEW_MODE_KEY)
 viewModeEl.value = savedViewMode
 applyViewMode(savedViewMode)
 viewModeEl.addEventListener('change', () => {
+    // Drop focus once picked (see the device select above).
+    viewModeEl.blur()
     const mode = viewModeEl.value
     localStorage.setItem(VIEW_MODE_KEY, mode)
     applyViewMode(mode)
@@ -368,7 +442,6 @@ startConnectedEl.addEventListener('change', () => {
     localStorage.setItem(START_CONNECTED_KEY, startConnectedEl.checked ? '1' : '0')
 })
 const manualConnectBtn = $<HTMLButtonElement>('manualConnect')
-const manualAbortBtn = $<HTMLButtonElement>('manualAbort')
 const walletBtn = $<HTMLButtonElement>('walletBtn')
 const walletProviderEl = $<HTMLSelectElement>('walletProvider')
 const logEl = $<HTMLDivElement>('log')
@@ -397,7 +470,12 @@ if (!isLocalHost) {
     })
 }
 
+const logCountEl = $<HTMLSpanElement>('logCount')
+let logCount = 0
+
 function appendLog(kind: LogKind, label: string, payload?: unknown) {
+    logCount++
+    logCountEl.textContent = String(logCount)
     const entry = document.createElement('div')
     entry.className = 'entry'
     const ts = new Date().toLocaleTimeString(undefined, { hour12: false })
@@ -423,7 +501,73 @@ function appendLog(kind: LogKind, label: string, payload?: unknown) {
 }
 
 clearLogBtn.addEventListener('click', () => {
+    logCount = 0
+    logCountEl.textContent = '0'
     logEl.innerHTML = ''
+})
+
+// "Window messages" drawer: raw postMessage recorder. Unlike the Event log
+// (which only shows traffic the bridge accepts — `from: 'bringweb3'` with an
+// action — and no sender metadata), this records EVERY message event this page
+// receives with its origin and source window (portal iframe / self / other
+// frame — e.g. a nested coupons iframe posting to `top`), plus every message
+// the wrapper posts to the portal. Collapsed by default; the summary badge
+// counts entries so activity is visible while closed.
+const msgLogEl = $<HTMLDivElement>('msgLog')
+const msgCountEl = $<HTMLSpanElement>('msgCount')
+const clearMsgLogBtn = $<HTMLButtonElement>('clearMsgLog')
+const MSG_LOG_MAX = 200
+const MSG_PAYLOAD_MAX = 2000
+let msgCount = 0
+
+const stringifyPayload = (data: unknown): string => {
+    let text: string
+    try {
+        text = typeof data === 'string' ? data : JSON.stringify(data, null, 2) ?? String(data)
+    } catch {
+        text = String(data)
+    }
+    return text.length > MSG_PAYLOAD_MAX
+        ? `${text.slice(0, MSG_PAYLOAD_MAX)}… (${text.length} chars)`
+        : text
+}
+
+const recordMessage = (direction: 'in' | 'out', meta: string, data: unknown) => {
+    msgCount++
+    msgCountEl.textContent = String(msgCount)
+    const entry = document.createElement('div')
+    entry.className = 'entry'
+    const head = document.createElement('span')
+    const tsSpan = document.createElement('span')
+    tsSpan.className = 'ts'
+    tsSpan.textContent = new Date().toLocaleTimeString(undefined, { hour12: false })
+    const labelSpan = document.createElement('span')
+    labelSpan.className = direction
+    const action = (data as { action?: unknown } | null)?.action
+    labelSpan.textContent = `${direction === 'in' ? '←' : '→'} ${typeof action === 'string' ? action : '(no action)'} · ${meta}`
+    head.append(tsSpan, labelSpan)
+    entry.appendChild(head)
+    const pre = document.createElement('div')
+    pre.textContent = stringifyPayload(data)
+    entry.appendChild(pre)
+    msgLogEl.appendChild(entry)
+    while (msgLogEl.childElementCount > MSG_LOG_MAX) msgLogEl.firstElementChild?.remove()
+    msgLogEl.scrollTop = msgLogEl.scrollHeight
+}
+
+const describeSource = (event: MessageEvent): string => {
+    const from = event.source === window ? 'self'
+        : event.source === iframeEl.contentWindow ? 'portal iframe'
+        : 'other frame'
+    return `${from} · ${event.origin || '(no origin)'}`
+}
+
+window.addEventListener('message', (event) => recordMessage('in', describeSource(event), event.data))
+
+clearMsgLogBtn.addEventListener('click', () => {
+    msgCount = 0
+    msgCountEl.textContent = '0'
+    msgLogEl.innerHTML = ''
 })
 
 const shortAddress = (addr: string) =>
@@ -574,7 +718,13 @@ walletProviderEl.addEventListener('change', async () => {
 const bridge = createPortalBridge({
     iframe: iframeEl,
     wallet: walletProxy,
-    log: appendLog,
+    // Outbound bridge posts also feed the raw "Window messages" drawer (inbound
+    // is covered by its own window listener; the bridge posts carry an implicit
+    // `to: 'bringweb3'` added in post()).
+    log: (kind, label, payload) => {
+        appendLog(kind, label, payload)
+        if (kind === 'out') recordMessage('out', 'to portal', payload)
+    },
     // LOGIN / SIGN_MESSAGE are always auto-answered (the bridge defaults to
     // responding); the old opt-out toggles were removed.
     refreshToken: async (address) => {
@@ -613,10 +763,6 @@ manualConnectBtn.addEventListener('click', () => {
         : undefined
     void bridge.connect(override)
 })
-manualAbortBtn.addEventListener('click', () => {
-    bridge.abortSign()
-})
-
 walletBtn.addEventListener('click', () => {
     if (walletBtn.dataset.state === 'connected') {
         void bridge.disconnect()
@@ -822,6 +968,11 @@ async function bootstrap(walletAddress: string | null): Promise<PortalApiRespons
         return null
     }
 
+    // Only a SUCCESSFUL bootstrap consumed the current inputs — clear the
+    // pending-edit highlight on the refresh icon now, not when the request
+    // starts, so a failed call leaves the icon blue (the portal still hasn't
+    // picked the edits up).
+    refreshBtn.classList.remove('dirty')
     lastUrlEl.value = portalUrl
     renderDecodedJwt(token)
     return data
@@ -846,10 +997,9 @@ async function refresh() {
         // SESSION_UPDATE — the same message used for wallet changes.
         try {
             const targetOrigin = new URL(iframeEl.src).origin
-            iframeEl.contentWindow?.postMessage(
-                { to: 'bringweb3', action: 'SESSION_UPDATE', token },
-                targetOrigin,
-            )
+            const msg = { to: 'bringweb3', action: 'SESSION_UPDATE', token }
+            iframeEl.contentWindow?.postMessage(msg, targetOrigin)
+            recordMessage('out', 'to portal', msg)
             setStatus('Posted refreshed token to iframe.')
         } catch (err) {
             setStatus(`postMessage failed: ${(err as Error).message}`, true)
@@ -862,6 +1012,63 @@ extensionEl.addEventListener('change', refresh)
 walletNameEl.addEventListener('change', refresh)
 walletEmojiEl.addEventListener('change', refresh)
 refreshBtn.addEventListener('click', refresh)
+
+// Text inputs only re-bootstrap on commit (blur/Enter), so while one is being
+// edited the portal is stale. Highlight the refresh icon until the next
+// bootstrap picks the edits up (committing the field, connecting the wallet,
+// or clicking the icon all clear it via bootstrap()).
+const markDirty = () => refreshBtn.classList.add('dirty')
+for (const el of [extensionEl, walletEl, walletNameEl, walletEmojiEl]) {
+    el.addEventListener('input', markDirty)
+}
+
+// Wallet identity persistence: "Start with this identity" stores the
+// name/emoji so a page reload restores them BEFORE the first bootstrap — the
+// very first check/portal call then already carries them, simulating an
+// integration that always sends the identity. The checkbox is only available
+// while a value is set, and the summary dot marks a set identity even when
+// the drawer is collapsed.
+const IDENTITY_KEY = 'bring-dev-wrapper:wallet-identity'
+const identityStartEl = $<HTMLInputElement>('identityStart')
+const identityDotEl = $<HTMLSpanElement>('identityDot')
+
+const saveIdentity = () => {
+    const name = walletNameEl.value.trim()
+    const emoji = walletEmojiEl.value.trim()
+    if (identityStartEl.checked && (name || emoji)) {
+        localStorage.setItem(IDENTITY_KEY, JSON.stringify({ name, emoji }))
+    } else {
+        localStorage.removeItem(IDENTITY_KEY)
+    }
+}
+
+const syncIdentityUi = () => {
+    const anySet = Boolean(walletNameEl.value.trim() || walletEmojiEl.value.trim())
+    identityDotEl.hidden = !anySet
+    identityStartEl.disabled = !anySet
+    // Clearing the last value withdraws the opt-in - nothing left to start with.
+    if (!anySet && identityStartEl.checked) {
+        identityStartEl.checked = false
+        saveIdentity()
+    }
+}
+
+// Restore before the initial refresh() below, so the first bootstrap already
+// includes the stored identity.
+try {
+    const stored = JSON.parse(localStorage.getItem(IDENTITY_KEY) || '') as { name?: string; emoji?: string }
+    if (stored.name) walletNameEl.value = stored.name
+    if (stored.emoji) walletEmojiEl.value = stored.emoji
+    if (stored.name || stored.emoji) identityStartEl.checked = true
+} catch { /* nothing stored */ }
+syncIdentityUi()
+
+identityStartEl.addEventListener('change', saveIdentity)
+for (const el of [walletNameEl, walletEmojiEl]) {
+    el.addEventListener('input', syncIdentityUi)
+    // Keep the stored copy in sync when an opted-in value is edited.
+    el.addEventListener('change', saveIdentity)
+}
 
 // Wallet input edits go through the bridge so the mock wallet's internal state
 // stays in sync and the same SESSION_UPDATE flow is used.

--- a/dev-wrapper/main.ts
+++ b/dev-wrapper/main.ts
@@ -77,6 +77,7 @@ const DEFAULT_EXT_ID = (env.VITE_PORTAL_EXTENSION_ID as string | undefined) ?? '
 const LOCAL_PORTAL_URL = (env.VITE_PORTAL_LOCAL_URL as string | undefined) ?? ''
 const DEFAULT_WALLET = (env.VITE_PORTAL_WALLET as string | undefined) ?? ''
 const DEFAULT_THEME = ((env.VITE_PORTAL_THEME as string | undefined) ?? '').trim().toLowerCase()
+const DEFAULT_VIEW_MODE = ((env.VITE_PORTAL_VIEW_MODE as string | undefined) ?? '').trim().toLowerCase()
 
 const $ = <T extends HTMLElement>(id: string) => {
     const el = document.getElementById(id)
@@ -147,12 +148,133 @@ const applyResponsiveSize = () => {
 }
 applyResponsiveSize()
 
+// Device presets (CSS viewport sizes, portrait) for the Mobile/Responsive
+// modes, mirroring browser devtools device emulation. In Mobile mode a preset
+// sizes the stage to the exact device viewport; in Responsive mode it drives
+// the width/height inputs, so drag-resize and manual edits still work (and
+// drop the selection back to "Custom"). Orientation is a separate flag so
+// rotate survives switching devices.
+type DevicePlatform = 'ios' | 'android'
+const DEVICES: { key: string; label: string; w: number; h: number; group: string; platform: DevicePlatform }[] = [
+    { key: 'iphone-se', label: 'iPhone SE', w: 375, h: 667, group: 'Phones', platform: 'ios' },
+    { key: 'iphone-14', label: 'iPhone 14', w: 390, h: 844, group: 'Phones', platform: 'ios' },
+    { key: 'iphone-16', label: 'iPhone 15 / 16', w: 393, h: 852, group: 'Phones', platform: 'ios' },
+    { key: 'iphone-17', label: 'iPhone 17', w: 402, h: 874, group: 'Phones', platform: 'ios' },
+    { key: 'iphone-17-pro-max', label: 'iPhone 17 Pro Max', w: 440, h: 956, group: 'Phones', platform: 'ios' },
+    { key: 'pixel-7', label: 'Pixel 7', w: 412, h: 915, group: 'Phones', platform: 'android' },
+    { key: 'galaxy-s8-plus', label: 'Galaxy S8+', w: 360, h: 740, group: 'Phones', platform: 'android' },
+    { key: 'galaxy-s20-ultra', label: 'Galaxy S20 Ultra', w: 412, h: 915, group: 'Phones', platform: 'android' },
+    { key: 'galaxy-z-fold', label: 'Galaxy Z Fold (folded)', w: 344, h: 882, group: 'Phones', platform: 'android' },
+    { key: 'ipad-mini', label: 'iPad Mini', w: 768, h: 1024, group: 'Tablets', platform: 'ios' },
+    { key: 'ipad-air', label: 'iPad Air', w: 820, h: 1180, group: 'Tablets', platform: 'ios' },
+    { key: 'ipad-pro-11', label: 'iPad Pro 11″', w: 834, h: 1194, group: 'Tablets', platform: 'ios' },
+    { key: 'ipad-pro-129', label: 'iPad Pro 12.9″', w: 1024, h: 1366, group: 'Tablets', platform: 'ios' },
+]
+const DEVICE_KEY = 'bring-dev-wrapper:device'
+const DEVICE_LANDSCAPE_KEY = 'bring-dev-wrapper:device-landscape'
+const deviceRowEl = $<HTMLDivElement>('deviceRow')
+const deviceEl = $<HTMLSelectElement>('devicePreset')
+const rotateBtn = $<HTMLButtonElement>('rotateDevice')
+
+{
+    const custom = document.createElement('option')
+    custom.value = ''
+    custom.textContent = 'Custom / default'
+    deviceEl.append(custom)
+    const groups = new Map<string, HTMLOptGroupElement>()
+    for (const device of DEVICES) {
+        let group = groups.get(device.group)
+        if (!group) {
+            group = document.createElement('optgroup')
+            group.label = device.group
+            groups.set(device.group, group)
+            deviceEl.append(group)
+        }
+        const option = document.createElement('option')
+        option.value = device.key
+        option.textContent = `${device.label} (${device.w}×${device.h})`
+        group.append(option)
+    }
+}
+
+let deviceLandscape = localStorage.getItem(DEVICE_LANDSCAPE_KEY) === '1'
+const savedDevice = localStorage.getItem(DEVICE_KEY) || ''
+deviceEl.value = DEVICES.some(d => d.key === savedDevice) ? savedDevice : ''
+
+const applyDevice = (mode: string) => {
+    deviceRowEl.hidden = mode !== 'mobile' && mode !== 'responsive'
+    const device = DEVICES.find(d => d.key === deviceEl.value)
+    // In Mobile mode with no device there's nothing to rotate (fixed 360px
+    // column); in Responsive mode rotate always works (swaps custom size too).
+    rotateBtn.disabled = !device && mode === 'mobile'
+    frameEl.classList.toggle('has-device', Boolean(device) && mode === 'mobile')
+    if (!device) return
+    const w = deviceLandscape ? device.h : device.w
+    const h = deviceLandscape ? device.w : device.h
+    if (mode === 'mobile') {
+        frameEl.style.setProperty('--device-w', `${w}px`)
+        frameEl.style.setProperty('--device-h', `${h}px`)
+    } else if (mode === 'responsive') {
+        savedSize.w = w
+        savedSize.h = h
+        responsiveWidthEl.value = String(w)
+        responsiveHeightEl.value = String(h)
+        applyResponsiveSize()
+        localStorage.setItem(RESPONSIVE_SIZE_KEY, JSON.stringify(savedSize))
+    }
+}
+
+// Platform hint sent in the check/portal body so the backend can bake the
+// coupon partner's `platform` param into couponsIframeSrc (explicit platform
+// instead of UA sniffing, which sees the desktop browser). Derived from the
+// device preset; plain Mobile mode defaults to ios, Desktop/custom-Responsive
+// send nothing. Harmlessly ignored until the backend supports the field.
+const getDevicePlatform = (): DevicePlatform | undefined => {
+    const device = DEVICES.find(d => d.key === deviceEl.value)
+    if (viewModeEl.value === 'mobile') return device?.platform ?? 'ios'
+    if (viewModeEl.value === 'responsive') return device?.platform
+    return undefined
+}
+
+// Manual size edits / drag-resize mean the size no longer matches the preset.
+const clearDeviceSelection = () => {
+    if (!deviceEl.value) return
+    deviceEl.value = ''
+    localStorage.setItem(DEVICE_KEY, '')
+    applyDevice(viewModeEl.value)
+}
+
+deviceEl.addEventListener('change', () => {
+    localStorage.setItem(DEVICE_KEY, deviceEl.value)
+    applyDevice(viewModeEl.value)
+    // Re-bootstrap so the portal re-evaluates useMobilePortal at the new width.
+    void refresh()
+})
+
+rotateBtn.addEventListener('click', () => {
+    if (!deviceEl.value && viewModeEl.value === 'responsive') {
+        // Custom size: rotate just swaps the current width/height.
+        ;[savedSize.w, savedSize.h] = [savedSize.h, savedSize.w]
+        responsiveWidthEl.value = String(savedSize.w)
+        responsiveHeightEl.value = String(savedSize.h)
+        applyResponsiveSize()
+        localStorage.setItem(RESPONSIVE_SIZE_KEY, JSON.stringify(savedSize))
+    } else {
+        deviceLandscape = !deviceLandscape
+        localStorage.setItem(DEVICE_LANDSCAPE_KEY, deviceLandscape ? '1' : '0')
+        applyDevice(viewModeEl.value)
+    }
+    void refresh()
+})
+
 const applyViewMode = (mode: string) => {
     frameEl.classList.toggle('mobile', mode === 'mobile')
     frameEl.classList.toggle('responsive', mode === 'responsive')
     responsiveSizeEl.hidden = mode !== 'responsive'
+    applyDevice(mode)
 }
-const savedViewMode = localStorage.getItem(VIEW_MODE_KEY) || 'desktop'
+const savedViewMode = localStorage.getItem(VIEW_MODE_KEY)
+    || (['desktop', 'mobile', 'responsive'].includes(DEFAULT_VIEW_MODE) ? DEFAULT_VIEW_MODE : 'desktop')
 viewModeEl.value = savedViewMode
 applyViewMode(savedViewMode)
 viewModeEl.addEventListener('change', () => {
@@ -182,6 +304,7 @@ const onSizeCommit = () => {
     responsiveWidthEl.value = String(savedSize.w)
     responsiveHeightEl.value = String(savedSize.h)
     localStorage.setItem(RESPONSIVE_SIZE_KEY, JSON.stringify(savedSize))
+    clearDeviceSelection()
     void refresh()
 }
 for (const el of [responsiveWidthEl, responsiveHeightEl]) {
@@ -217,6 +340,7 @@ const setupResizeHandle = (id: string, axes: { x?: boolean; y?: boolean }) => {
             frameEl.classList.remove('resizing')
             if (savedSize.w === startW && savedSize.h === startH) return
             localStorage.setItem(RESPONSIVE_SIZE_KEY, JSON.stringify(savedSize))
+            clearDeviceSelection()
             // Re-bootstrap at the final size (portal reads innerWidth once).
             void refresh()
         }
@@ -653,6 +777,9 @@ async function bootstrap(walletAddress: string | null): Promise<PortalApiRespons
         // Empty string means "don't include theme in the payload" so the
         // portal/API uses its own defaults.
         theme: (themeEl.value || undefined) as Theme | undefined,
+        // Platform of the emulated device, so the backend can pass it through
+        // to platform-sensitive iframe URLs (e.g. AppCard coupons).
+        devicePlatform: getDevicePlatform(),
     }
 
     const requestId = ++pendingId

--- a/dev-wrapper/style.css
+++ b/dev-wrapper/style.css
@@ -111,6 +111,93 @@ html, body {
 .logout-btn:hover { color: #e7e9ee; }
 .logout-btn[hidden] { display: none; }
 
+/* Centre cluster of the header: compact viewport/display controls (view mode,
+   device preset, stage size, wrapper background). Label-free — tooltips carry
+   the explanations. Interactive tooling chrome, so like the sidebar it's
+   raised above the visual-diff overlay layers (see Z_LAYER in
+   visualDiffOverlay.ts). */
+.view-toolbar {
+    position: relative;
+    z-index: 2147483640;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px;
+}
+
+.view-toolbar select,
+.view-toolbar input {
+    background: #15191f;
+    border: 1px solid #2a313c;
+    color: #e7e9ee;
+    border-radius: 6px;
+    padding: 5px 8px;
+    font-size: 12px;
+    font-family: inherit;
+}
+
+.view-toolbar input[type="number"] {
+    width: 62px;
+}
+
+.view-toolbar input[type="color"] {
+    width: 34px;
+    height: 28px;
+    padding: 2px;
+    cursor: pointer;
+}
+
+.view-toolbar button {
+    background: #1f2530;
+    border: 1px solid #2a313c;
+    color: #e7e9ee;
+    border-radius: 6px;
+    padding: 5px 9px;
+    font-size: 12px;
+    font-family: inherit;
+    line-height: 1.3;
+    cursor: pointer;
+}
+
+.view-toolbar button:hover { background: #262d3a; }
+
+.view-toolbar button:disabled,
+.view-toolbar select:disabled,
+.view-toolbar input:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.view-toolbar button.active {
+    background: #3d5aeb;
+    border-color: #3d5aeb;
+}
+
+.view-toolbar button.active:hover { background: #2e48d9; }
+
+.view-toolbar .tb-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.view-toolbar .tb-x {
+    color: #8a93a3;
+    font-size: 12px;
+}
+
+/* Right side of the header; mirrors the flexible title side so the toolbar
+   stays centred. */
+.bar-actions {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 16px;
+}
+
 .layout {
     position: relative;
     display: grid;
@@ -284,15 +371,88 @@ html, body {
     gap: 8px;
 }
 
+.controls label.row { cursor: pointer; }
+
+/* Custom checkboxes: native look replaced with a rounded square that fills
+   with the accent blue and pops in a checkmark (clip-path) when checked. */
 .controls .row input[type="checkbox"] {
-    width: auto;
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
     margin: 0;
+    flex: none;
+    display: inline-grid;
+    place-content: center;
+    background: #15191f;
+    border: 1px solid #3a4351;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
 }
 
-.controls .btn-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+.controls .row input[type="checkbox"]::before {
+    content: "";
+    width: 9px;
+    height: 9px;
+    background: #7ba6ff;
+    clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+    transform: scale(0);
+    transition: transform 0.12s ease-in-out;
+}
+
+/* Checked state stays quiet: same dark fill, just a blue border + blue tick
+   (a solid accent fill read as too dominant next to the muted sidebar). */
+.controls .row input[type="checkbox"]:checked {
+    background: #1a2030;
+    border-color: #3d5aeb;
+}
+
+.controls .row input[type="checkbox"]:checked::before { transform: scale(1); }
+
+.controls .row input[type="checkbox"]:hover:not(:disabled):not(:checked) {
+    border-color: #4a5568;
+}
+
+.controls .row input[type="checkbox"]:focus-visible {
+    outline: 2px solid rgba(61, 90, 235, 0.5);
+    outline-offset: 1px;
+}
+
+.controls .row input[type="checkbox"]:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+/* Checkbox row with a link-styled action on the right (e.g. "Start connected"
+   + "Send connect"). */
+.controls .row-split {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     gap: 8px;
+    margin-bottom: 10px;
+}
+
+.controls .row-split .row { margin-bottom: 0; }
+
+.controls button.link-btn {
+    width: auto;
+    flex: none;
+    background: none;
+    border: 0;
+    padding: 0;
+    color: #7ba6ff;
+    font-size: 12px;
+    font-weight: 500;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+}
+
+.controls button.link-btn:hover {
+    background: none;
+    color: #a9c4ff;
 }
 
 .log {
@@ -347,6 +507,27 @@ html, body {
 
 .controls .debug label {
     margin-top: 10px;
+}
+
+/* Entry-count badge in the "Window messages" summary — shows activity while
+   the drawer is collapsed. */
+.msg-count {
+    display: inline-block;
+    min-width: 18px;
+    margin-left: 8px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: #1f2530;
+    border: 1px solid #2a313c;
+    color: #8a93a3;
+    font-size: 10px;
+    text-align: center;
+    text-transform: none;
+    letter-spacing: normal;
+}
+
+.controls .debug .log {
+    margin-top: 8px;
 }
 
 .jwt-decoded {
@@ -489,44 +670,69 @@ html, body {
     background: #fff;
 }
 
-.responsive-size {
+/* Collapsible drawers nested inside a fieldset (e.g. the Wallet group's
+   identity fields) sit flush with the fieldset's own bottom padding. */
+.controls fieldset .debug {
+    margin: 10px 0 0;
+}
+
+/* Green dot on the Wallet identity summary: a value is set inside, visible
+   even while the drawer is collapsed. */
+.identity-dot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #3ddc84;
+    margin-left: 8px;
+    vertical-align: middle;
+}
+
+.identity-dot[hidden] { display: none; }
+
+.controls .row input:disabled + span { opacity: 0.5; }
+
+/* Top row of the sidebar: API path plus the small re-bootstrap icon. The
+   refresh lives here (not in a fieldset) because it re-runs the call with
+   EVERYTHING below — Bootstrap params and wallet state alike. */
+.api-row {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
     gap: 8px;
+    margin: -6px 0 12px;
 }
 
-.responsive-size[hidden] {
-    display: none;
-}
+.api-row .api-info { margin: 0; }
 
-/* Device preset select + rotate button on one row. */
-.device-row {
-    display: flex;
-    align-items: flex-end;
-    gap: 8px;
-}
-
-.device-row[hidden] {
-    display: none;
-}
-
-.device-row label {
-    flex: 1;
-    min-width: 0;
-}
-
-.device-row .rotate {
+.api-row .refresh-icon {
     width: auto;
     flex: none;
-    padding: 6px 10px;
-    margin-bottom: 10px;
-    font-size: 15px;
-    line-height: 1.2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 5px 7px;
+    color: #b7bdc9;
 }
 
-.device-row .rotate:disabled {
-    opacity: 0.4;
-    cursor: default;
+.api-row .refresh-icon:hover { color: #e7e9ee; }
+
+.api-row .refresh-icon svg {
+    display: block;
+    transition: transform 0.25s ease;
 }
+
+.api-row .refresh-icon:hover svg { transform: rotate(90deg); }
+
+/* Uncommitted text-field edits: the portal hasn't re-bootstrapped with them
+   yet, so the refresh icon lights up until the next bootstrap runs. */
+.api-row .refresh-icon.dirty {
+    background: #3d5aeb;
+    border-color: #3d5aeb;
+    color: #fff;
+}
+
+.api-row .refresh-icon.dirty:hover { background: #2e48d9; }
 
 /* Drag-resize handles: only active in responsive mode. Pointer capture on the
    handle keeps the drag alive even when the cursor crosses the iframe. */
@@ -578,11 +784,6 @@ html, body {
 
 .frame.resizing iframe {
     pointer-events: none;
-}
-
-.responsive-size label {
-    flex: 1;
-    min-width: 0;
 }
 
 .frame iframe {

--- a/dev-wrapper/style.css
+++ b/dev-wrapper/style.css
@@ -454,6 +454,20 @@ html, body {
     background: #fff;
 }
 
+/* Mobile view with a device preset: exact device viewport, centered, scroll
+   when the device is larger than the available frame area. */
+.frame.mobile.has-device {
+    align-items: safe center;
+    padding: 16px;
+    overflow: auto;
+}
+
+.frame.mobile.has-device .frame-stage {
+    flex: none;
+    width: var(--device-w, 360px);
+    height: var(--device-h, 640px);
+}
+
 /* Responsive view: exact user-set dimensions via CSS variables, centered in
    the frame with scroll overflow when the stage is larger than the viewport. */
 .frame.responsive {
@@ -482,6 +496,36 @@ html, body {
 
 .responsive-size[hidden] {
     display: none;
+}
+
+/* Device preset select + rotate button on one row. */
+.device-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+}
+
+.device-row[hidden] {
+    display: none;
+}
+
+.device-row label {
+    flex: 1;
+    min-width: 0;
+}
+
+.device-row .rotate {
+    width: auto;
+    flex: none;
+    padding: 6px 10px;
+    margin-bottom: 10px;
+    font-size: 15px;
+    line-height: 1.2;
+}
+
+.device-row .rotate:disabled {
+    opacity: 0.4;
+    cursor: default;
 }
 
 /* Drag-resize handles: only active in responsive mode. Pointer capture on the

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -19,6 +19,8 @@
  *     remove it, `clear` removes all); each shows a live px readout
  *   - `ruler` arms a measuring tape: press-drag between two dots to read the
  *     pixel distance; both dots stay draggable (double-click / Delete removes)
+ *   - `arrow` arms an annotation arrow: press-drag from where the label should
+ *     sit to what you're pointing at; click the label chip to type a note
  *   - `hide` / `lock` / `reset`
  *
  * Note: this overlays the dev-wrapper page itself, NOT the portal rendered
@@ -34,6 +36,19 @@ type Guide = { id: string; axis: 'x' | 'y'; pos: number }
 // A free-angle measuring tape between two viewport points (CSS px). The label
 // shows the straight-line distance between them.
 type Ruler = { id: string; x1: number; y1: number; x2: number; y2: number }
+
+// A free-angle annotation arrow. Same geometry as a Ruler — (x1,y1) is the
+// tail you start the drag from, (x2,y2) the head it points at — but drawn as a
+// thick shaft with a solid head, and carrying no measurement.
+type Arrow = {
+    id: string
+    x1: number
+    y1: number
+    x2: number
+    y2: number
+    // Free text shown in a chip at the tail. Empty until you type one in.
+    text: string
+}
 
 type State = {
     src: string
@@ -52,6 +67,9 @@ type State = {
     gridColor: string
     guides: Guide[]
     rulers: Ruler[]
+    arrows: Arrow[]
+    arrowColor: string
+    arrowWidth: number
 }
 
 const STORAGE_KEY = 'bring.visualDiff.wrapper.v1'
@@ -102,6 +120,12 @@ const DEFAULTS: State = {
     gridColor: '#FF2D9B',
     guides: [],
     rulers: [],
+    arrows: [],
+    // Distinct from every other tool colour (guides cyan, rulers amber, grid
+    // pink, active-state yellow) so an annotation is never mistaken for a
+    // measurement.
+    arrowColor: '#FF3B30',
+    arrowWidth: 6,
 }
 
 const loadState = (): State => {
@@ -407,7 +431,8 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         return Number.isFinite(n) ? Math.max(m, n + 1) : m
     }, 1)
     let hoveredRulerId: string | null = null
-    let rulerArmed = false
+    // Which draw mode the shared catcher is in, if any.
+    let rulerArmed: null | 'ruler' | 'arrow' = null
 
     // With Shift held, snap a stretched endpoint to a pure horizontal or
     // vertical line relative to the anchor (whichever axis the drag favours),
@@ -550,6 +575,328 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         return id
     }
 
+    // --- annotation arrows -------------------------------------------------
+    // Thick free-angle arrows for pointing at things, each with an optional
+    // text label in a chip at the tail. Arm with the "arrow" button, then
+    // press-drag from where the label should sit to whatever you're pointing
+    // at. Both endpoints stay draggable; click the chip to type. Shift
+    // constrains the angle to horizontal/vertical, as with rulers.
+    const arrowEls = new Map<string, HTMLDivElement>()
+    let arrowSeq = state.arrows.reduce((m, a) => {
+        const n = Number(a.id.replace(/^a/, ''))
+        return Number.isFinite(n) ? Math.max(m, n + 1) : m
+    }, 1)
+    let hoveredArrowId: string | null = null
+
+    const arrowColor = () =>
+        /^#[0-9a-fA-F]{6}$/.test(state.arrowColor) ? state.arrowColor : DEFAULTS.arrowColor
+    // Chip text flips to dark on light arrow colours so the label stays
+    // legible whatever colour is chosen.
+    const chipTextColor = () => {
+        const hex = arrowColor()
+        const [r, g, b] = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16))
+        return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255 > 0.6 ? '#1a1a1a' : '#ffffff'
+    }
+
+    const removeArrow = (id: string) => {
+        state = { ...state, arrows: state.arrows.filter(a => a.id !== id) }
+        if (hoveredArrowId === id) hoveredArrowId = null
+        renderArrows()
+        save()
+    }
+
+    const positionArrow = (id: string) => {
+        const el = arrowEls.get(id)
+        const a = state.arrows.find(aa => aa.id === id)
+        if (!el || !a) return
+        const w = Math.max(1, state.arrowWidth)
+        const dx = a.x2 - a.x1
+        const dy = a.y2 - a.y1
+        const len = Math.hypot(dx, dy) || 1
+        const ux = dx / len
+        const uy = dy / len
+        // Head scales with thickness; clamped so a very short arrow stays an
+        // arrow rather than collapsing into a triangle with no shaft.
+        const headLen = Math.min(len * 0.6, w * 3.2 + 6)
+        const headHalf = headLen * 0.62
+        const bx = a.x2 - ux * headLen
+        const by = a.y2 - uy * headLen
+        // Perpendicular, for the head's base corners.
+        const px = -uy
+        const py = ux
+
+        const shaft = el.querySelector('[data-a="shaft"]') as SVGLineElement
+        const shaftOutline = el.querySelector('[data-a="shaftOutline"]') as SVGLineElement
+        for (const line of [shaftOutline, shaft]) {
+            line.setAttribute('x1', String(a.x1))
+            line.setAttribute('y1', String(a.y1))
+            line.setAttribute('x2', String(bx))
+            line.setAttribute('y2', String(by))
+        }
+        shaft.setAttribute('stroke', arrowColor())
+        shaft.setAttribute('stroke-width', String(w))
+        shaftOutline.setAttribute('stroke-width', String(w + 3))
+
+        const pts = [
+            `${a.x2},${a.y2}`,
+            `${bx + px * headHalf},${by + py * headHalf}`,
+            `${bx - px * headHalf},${by - py * headHalf}`,
+        ].join(' ')
+        const head = el.querySelector('[data-a="head"]') as SVGPolygonElement
+        const headOutline = el.querySelector('[data-a="headOutline"]') as SVGPolygonElement
+        head.setAttribute('points', pts)
+        head.setAttribute('fill', arrowColor())
+        headOutline.setAttribute('points', pts)
+
+        // Label + delete button sit just beyond the tail, on the far side from
+        // the head, so they never cover the shaft or the thing being pointed at.
+        const chipWrap = el.querySelector('[data-a="chipWrap"]') as HTMLElement
+        const chip = el.querySelector('[data-a="chip"]') as HTMLElement
+        const off = 14 + w
+        chipWrap.style.left = `${a.x1 - ux * off}px`
+        chipWrap.style.top = `${a.y1 - uy * off}px`
+        chip.style.background = arrowColor()
+        chip.style.color = chipTextColor()
+        if (chip.textContent !== a.text && document.activeElement !== chip) {
+            chip.textContent = a.text
+        }
+        chip.classList.toggle('is-empty', !a.text)
+
+        const h1 = el.querySelector('[data-h="1"]') as HTMLElement
+        const h2 = el.querySelector('[data-h="2"]') as HTMLElement
+        h1.style.left = `${a.x1}px`
+        h1.style.top = `${a.y1}px`
+        h2.style.left = `${a.x2}px`
+        h2.style.top = `${a.y2}px`
+        for (const h of [h1, h2]) h.style.background = arrowColor()
+    }
+
+    const makeArrowEl = (arrow: Arrow): HTMLDivElement => {
+        const container = document.createElement('div')
+        Object.assign(container.style, {
+            position: 'fixed', inset: '0', zIndex: Z_LAYER, pointerEvents: 'none',
+        } as CSSStyleDeclaration)
+
+        const svg = document.createElementNS(SVG_NS, 'svg')
+        Object.assign(svg.style, { position: 'absolute', inset: '0', width: '100%', height: '100%', overflow: 'visible' } as CSSStyleDeclaration)
+        // Dark outline drawn under the shaft/head keeps the arrow readable over
+        // both a dark page and a light design overlay.
+        const OUTLINE = 'rgba(0,0,0,0.55)'
+        const mkLine = (name: string, stroke: string) => {
+            const l = document.createElementNS(SVG_NS, 'line')
+            l.setAttribute('data-a', name)
+            l.setAttribute('stroke', stroke)
+            l.setAttribute('stroke-linecap', 'round')
+            return l
+        }
+        const mkPoly = (name: string, extra: Record<string, string>) => {
+            const p = document.createElementNS(SVG_NS, 'polygon')
+            p.setAttribute('data-a', name)
+            for (const [k, v] of Object.entries(extra)) p.setAttribute(k, v)
+            return p
+        }
+        svg.append(
+            mkLine('shaftOutline', OUTLINE),
+            mkPoly('headOutline', { fill: OUTLINE, stroke: OUTLINE, 'stroke-width': '3', 'stroke-linejoin': 'round' }),
+            mkLine('shaft', arrowColor()),
+            mkPoly('head', { fill: arrowColor() }),
+        )
+        container.appendChild(svg)
+
+        // Label and its delete button ride together in one absolutely-
+        // positioned row, so the ✕ tracks the chip whatever width the text
+        // gives it.
+        const chipWrap = document.createElement('div')
+        chipWrap.setAttribute('data-a', 'chipWrap')
+        Object.assign(chipWrap.style, {
+            position: 'absolute',
+            transform: 'translate(-50%, -50%)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            // Hit-testable so hovering anywhere across label-gap-button counts
+            // as being on the arrow; without it the pointer crossing the 4px
+            // gap would flicker the controls off and on.
+            pointerEvents: 'auto',
+        } as CSSStyleDeclaration)
+
+        const chip = document.createElement('div')
+        chip.setAttribute('data-a', 'chip')
+        chip.className = 'bring-arrow-chip'
+        chip.contentEditable = 'true'
+        chip.spellcheck = false
+        chip.title = 'Click to edit · Enter to finish'
+        Object.assign(chip.style, {
+            font: '600 11px/1.35 ui-monospace, SFMono-Regular, Menlo, monospace',
+            padding: '3px 7px',
+            borderRadius: '5px',
+            maxWidth: '260px',
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            textAlign: 'center',
+            pointerEvents: 'auto',
+            cursor: 'text',
+            outline: 'none',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.45)',
+        } as CSSStyleDeclaration)
+        // Keep clicks/keys inside the chip local: they must not start an
+        // endpoint drag, trip pick mode, or reach the global arrow-nudge
+        // handler.
+        chip.addEventListener('pointerdown', (e) => e.stopPropagation())
+        chip.addEventListener('click', (e) => e.stopPropagation())
+        chip.addEventListener('keydown', (e) => {
+            e.stopPropagation()
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                chip.blur()
+            } else if (e.key === 'Escape') {
+                e.preventDefault()
+                chip.blur()
+            }
+        })
+        const commit = () => {
+            const text = (chip.textContent ?? '').trim()
+            state = { ...state, arrows: state.arrows.map(a => a.id === arrow.id ? { ...a, text } : a) }
+            chip.classList.toggle('is-empty', !text)
+            save()
+        }
+        chip.addEventListener('input', commit)
+        chip.addEventListener('blur', () => {
+            commit()
+            positionArrow(arrow.id)
+        })
+
+        // Explicit per-arrow delete. Double-clicking an endpoint and Delete-
+        // while-hovering both still work, but neither is discoverable — this is
+        // the obvious way to remove one particular arrow.
+        const delBtn = document.createElement('button')
+        delBtn.setAttribute('data-a', 'del')
+        delBtn.type = 'button'
+        delBtn.textContent = '✕'
+        delBtn.title = 'Remove this arrow'
+        Object.assign(delBtn.style, {
+            flex: '0 0 auto',
+            width: '18px',
+            height: '18px',
+            lineHeight: '1',
+            padding: '0',
+            borderRadius: '50%',
+            border: '1px solid rgba(255,255,255,0.25)',
+            background: 'rgba(20,22,28,0.92)',
+            color: '#F5F8FF',
+            font: '11px/1 ui-monospace, SFMono-Regular, Menlo, monospace',
+            cursor: 'pointer',
+            pointerEvents: 'auto',
+            opacity: '0',
+            transition: 'opacity 0.12s, filter 0.12s',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.45)',
+        } as CSSStyleDeclaration)
+        delBtn.addEventListener('pointerdown', (e) => {
+            // Must not start an endpoint drag or reach the page underneath.
+            e.preventDefault()
+            e.stopPropagation()
+        })
+        delBtn.addEventListener('click', (e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            removeArrow(arrow.id)
+        })
+
+        chipWrap.append(chip, delBtn)
+        container.appendChild(chipWrap)
+
+        const mkHandle = (which: 1 | 2): HTMLDivElement => {
+            const h = document.createElement('div')
+            h.setAttribute('data-h', String(which))
+            Object.assign(h.style, {
+                position: 'absolute', width: '13px', height: '13px',
+                marginLeft: '-7px', marginTop: '-7px', borderRadius: '50%',
+                border: '2px solid rgba(0,0,0,0.55)', boxSizing: 'border-box',
+                pointerEvents: 'auto', cursor: 'grab', touchAction: 'none',
+                opacity: '0', transition: 'opacity 0.12s',
+            } as CSSStyleDeclaration)
+            h.title = which === 1
+                ? 'Drag to move the tail · double-click or Delete to remove'
+                : 'Drag to move the point · double-click or Delete to remove'
+            h.addEventListener('pointerdown', (e: PointerEvent) => {
+                e.preventDefault()
+                e.stopPropagation()
+                h.setPointerCapture(e.pointerId)
+                const kx = which === 1 ? 'x1' : 'x2'
+                const ky = which === 1 ? 'y1' : 'y2'
+                const move = (ev: PointerEvent) => {
+                    const cur = state.arrows.find(a => a.id === arrow.id)
+                    const ax = which === 1 ? (cur?.x2 ?? ev.clientX) : (cur?.x1 ?? ev.clientX)
+                    const ay = which === 1 ? (cur?.y2 ?? ev.clientY) : (cur?.y1 ?? ev.clientY)
+                    const p = constrainToAxis(ax, ay, ev.clientX, ev.clientY, ev.shiftKey)
+                    state = { ...state, arrows: state.arrows.map(a => a.id === arrow.id ? { ...a, [kx]: Math.round(p.x), [ky]: Math.round(p.y) } : a) }
+                    positionArrow(arrow.id)
+                }
+                const up = (ev: PointerEvent) => {
+                    h.removeEventListener('pointermove', move)
+                    h.removeEventListener('pointerup', up)
+                    h.removeEventListener('pointercancel', up)
+                    try { h.releasePointerCapture(ev.pointerId) } catch { /* already released */ }
+                    save()
+                }
+                h.addEventListener('pointermove', move)
+                h.addEventListener('pointerup', up)
+                h.addEventListener('pointercancel', up)
+            })
+            h.addEventListener('dblclick', (e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                removeArrow(arrow.id)
+            })
+            return h
+        }
+        const handles = [mkHandle(1), mkHandle(2)]
+        container.append(...handles)
+
+        // Controls stay invisible until you're on the arrow, so annotations
+        // read as clean graphics in a screenshot but are still editable on
+        // approach.
+        const setHandleVis = (on: boolean) => {
+            hoveredArrowId = on ? arrow.id : hoveredArrowId === arrow.id ? null : hoveredArrowId
+            for (const h of handles) h.style.opacity = on ? '1' : '0'
+            delBtn.style.opacity = on ? '1' : '0'
+            // Opacity alone leaves it clickable — a hidden ✕ next to the label
+            // would delete an arrow on a stray click.
+            delBtn.style.pointerEvents = on ? 'auto' : 'none'
+        }
+        for (const el of [chipWrap, ...handles]) {
+            el.addEventListener('pointerenter', () => setHandleVis(true))
+            el.addEventListener('pointerleave', () => setHandleVis(false))
+        }
+        // While the label has focus the ✕ must stay put — it would otherwise
+        // vanish the moment the pointer left the chip to go click it.
+        chip.addEventListener('focus', () => setHandleVis(true))
+
+        return container
+    }
+
+    function renderArrows() {
+        const ids = new Set(state.arrows.map(a => a.id))
+        for (const [id, el] of arrowEls) {
+            if (!ids.has(id)) { el.remove(); arrowEls.delete(id) }
+        }
+        for (const arrow of state.arrows) {
+            if (!arrowEls.has(arrow.id)) {
+                const el = makeArrowEl(arrow)
+                arrowEls.set(arrow.id, el)
+                document.body.appendChild(el)
+            }
+            positionArrow(arrow.id)
+        }
+    }
+
+    const addArrow = (x1: number, y1: number, x2: number, y2: number): string => {
+        const id = `a${arrowSeq++}`
+        state = { ...state, arrows: [...state.arrows, { id, x1, y1, x2, y2, text: '' }] }
+        renderArrows()
+        return id
+    }
+
     // --- control panel -----------------------------------------------------
     const panel = document.createElement('div')
     Object.assign(panel.style, {
@@ -602,6 +949,13 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         }
         #bring-visual-diff-panel [data-act="clearUrl"] { opacity: 0.6; }
         #bring-visual-diff-panel [data-act="clearUrl"]:hover { opacity: 1; }
+        /* Empty arrow labels shrink to a faint hint rather than an invisible
+           zero-width box, so they stay clickable and discoverable. */
+        .bring-arrow-chip.is-empty::before {
+            content: 'label';
+            opacity: 0.65;
+        }
+        .bring-arrow-chip.is-empty:focus::before { content: none; }
     `
     document.head.appendChild(styleTag)
 
@@ -676,6 +1030,16 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             <button data-act="ruler" title="Measure a distance: click this, then press-drag between two points. Drag the dots to adjust; double-click a dot or press Delete to remove." style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">ruler</button>
             <button data-act="clearRulers" title="Remove all measuring lines" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">clear</button>
         </div>
+        <div style="display:flex;align-items:center;gap:4px;margin-top:6px;flex-wrap:wrap">
+            <span style="width:56px;color:#9aa0a6">Arrow</span>
+            <button data-act="arrow" title="Point at something: click this, then press-drag from where the label should sit to what you're pointing at (shift = straight). Click the label to type; drag the dots to adjust; double-click a dot or press Delete to remove." style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">arrow</button>
+            <button data-act="clearArrows" title="Remove all arrows" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">clear</button>
+            <span style="display:flex;align-items:center;gap:4px;margin-left:60px">
+                <input type="color" data-el="arrowColor" title="Arrow colour (applies to all arrows)" style="width:28px;height:24px;padding:0;background:#0e1116;border:1px solid #2a2d33;border-radius:4px;cursor:pointer">
+                <input type="number" min="1" max="40" step="1" data-el="arrowWidth" title="Arrow thickness (applies to all arrows)" style="width:46px;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+                <span style="color:#66686E;font-size:11px">px</span>
+            </span>
+        </div>
         <div data-el="inspectRow">
             <div style="display:flex;align-items:center;gap:4px;margin-top:6px;flex-wrap:wrap">
                 <span style="width:56px;color:#9aa0a6">Inspect</span>
@@ -708,6 +1072,9 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     const gridSizeInput = q<HTMLInputElement>('[data-el="gridSize"]')
     const gridColorInput = q<HTMLInputElement>('[data-el="gridColor"]')
     const rulerBtn = q<HTMLButtonElement>('[data-act="ruler"]')
+    const arrowBtn = q<HTMLButtonElement>('[data-act="arrow"]')
+    const arrowColorInput = q<HTMLInputElement>('[data-el="arrowColor"]')
+    const arrowWidthInput = q<HTMLInputElement>('[data-el="arrowWidth"]')
     const pickBtn = q<HTMLButtonElement>('[data-act="pick"]')
     const pickInfo = q<HTMLElement>('[data-el="pickInfo"]')
     const inspectRow = q<HTMLDivElement>('[data-el="inspectRow"]')
@@ -738,34 +1105,60 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     } as CSSStyleDeclaration)
     document.body.appendChild(rulerCatcher)
 
-    const setRulerArmed = (on: boolean) => {
-        rulerArmed = on
-        rulerCatcher.style.display = on ? '' : 'none'
-        rulerBtn.textContent = on ? 'drawing… (Esc)' : 'ruler'
-        rulerBtn.style.background = on ? '#FFEF46' : '#2a2d33'
-        rulerBtn.style.color = on ? '#1F2018' : '#F5F8FF'
+    // Rulers and arrows share one catcher, so arming either disarms the other.
+    const setArmed = (mode: null | 'ruler' | 'arrow') => {
+        rulerArmed = mode
+        rulerCatcher.style.display = mode ? '' : 'none'
+        const paint = (btn: HTMLButtonElement, label: string, on: boolean) => {
+            btn.textContent = on ? 'drawing… (Esc)' : label
+            btn.style.background = on ? '#FFEF46' : '#2a2d33'
+            btn.style.color = on ? '#1F2018' : '#F5F8FF'
+        }
+        paint(rulerBtn, 'ruler', mode === 'ruler')
+        paint(arrowBtn, 'arrow', mode === 'arrow')
     }
 
     rulerCatcher.addEventListener('pointerdown', (e: PointerEvent) => {
+        if (!rulerArmed) return
         e.preventDefault()
         rulerCatcher.setPointerCapture(e.pointerId)
+        const drawingArrow = rulerArmed === 'arrow'
         const x = Math.round(e.clientX), y = Math.round(e.clientY)
-        const id = addRuler(x, y, x, y)
+        const id = drawingArrow ? addArrow(x, y, x, y) : addRuler(x, y, x, y)
         const move = (ev: PointerEvent) => {
             // Anchor on the press point so Shift constrains to H/V from there.
             const p = constrainToAxis(x, y, ev.clientX, ev.clientY, ev.shiftKey)
-            state = { ...state, rulers: state.rulers.map(r => r.id === id ? { ...r, x2: Math.round(p.x), y2: Math.round(p.y) } : r) }
-            positionRuler(id)
+            const x2 = Math.round(p.x), y2 = Math.round(p.y)
+            if (drawingArrow) {
+                state = { ...state, arrows: state.arrows.map(a => a.id === id ? { ...a, x2, y2 } : a) }
+                positionArrow(id)
+            } else {
+                state = { ...state, rulers: state.rulers.map(r => r.id === id ? { ...r, x2, y2 } : r) }
+                positionRuler(id)
+            }
         }
         const up = (ev: PointerEvent) => {
             rulerCatcher.removeEventListener('pointermove', move)
             rulerCatcher.removeEventListener('pointerup', up)
             rulerCatcher.removeEventListener('pointercancel', up)
             try { rulerCatcher.releasePointerCapture(ev.pointerId) } catch { /* already released */ }
-            // A plain click (no real drag) leaves a degenerate ruler — drop it.
-            const r = state.rulers.find(rr => rr.id === id)
-            if (r && Math.hypot(r.x2 - r.x1, r.y2 - r.y1) < 3) removeRuler(id)
-            else save()
+            // A plain click (no real drag) leaves a degenerate shape — drop it.
+            const shape = drawingArrow
+                ? state.arrows.find(a => a.id === id)
+                : state.rulers.find(r => r.id === id)
+            if (shape && Math.hypot(shape.x2 - shape.x1, shape.y2 - shape.y1) < 3) {
+                if (drawingArrow) removeArrow(id)
+                else removeRuler(id)
+                return
+            }
+            save()
+            if (drawingArrow) {
+                // Drop straight into typing the label — the point of an arrow
+                // is usually the note attached to it.
+                setArmed(null)
+                const chip = arrowEls.get(id)?.querySelector('[data-a="chip"]') as HTMLElement | null
+                chip?.focus()
+            }
         }
         rulerCatcher.addEventListener('pointermove', move)
         rulerCatcher.addEventListener('pointerup', up)
@@ -889,6 +1282,8 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         gridBtn.style.color = state.grid ? '#1F2018' : '#F5F8FF'
         if (gridSizeInput !== document.activeElement) gridSizeInput.value = String(state.gridSize)
         if (gridColorInput.value.toLowerCase() !== state.gridColor.toLowerCase()) gridColorInput.value = state.gridColor
+        if (arrowColorInput.value.toLowerCase() !== state.arrowColor.toLowerCase()) arrowColorInput.value = state.arrowColor
+        if (arrowWidthInput !== document.activeElement) arrowWidthInput.value = String(state.arrowWidth)
         // Highlight "fit" while fitted; clicking again restores the prior size.
         fitBtn.style.background = preFit ? '#FFEF46' : '#2a2d33'
         fitBtn.style.color = preFit ? '#1F2018' : '#F5F8FF'
@@ -938,6 +1333,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         applyGrid()
         renderGuides()
         renderRulers()
+        renderArrows()
         save()
     }
 
@@ -1047,7 +1443,7 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
             resetScaleAndCenter()
         }
     })
-    const onNumberInput = (el: HTMLInputElement, key: 'x' | 'y' | 'scale' | 'opacity' | 'gridSize', fallback: number) => {
+    const onNumberInput = (el: HTMLInputElement, key: 'x' | 'y' | 'scale' | 'opacity' | 'gridSize' | 'arrowWidth', fallback: number) => {
         el.addEventListener('input', () => {
             // Skip while the field is mid-edit (e.g. just `-` or empty) so we
             // don't replace the caret content; commit on blur instead.
@@ -1069,8 +1465,13 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     onNumberInput(scaleInput, 'scale', 1)
     onNumberInput(opacityInput, 'opacity', 0.5)
     onNumberInput(gridSizeInput, 'gridSize', 8)
+    onNumberInput(arrowWidthInput, 'arrowWidth', 6)
     gridColorInput.addEventListener('input', () => {
         state = { ...state, gridColor: gridColorInput.value }
+        syncUi()
+    })
+    arrowColorInput.addEventListener('input', () => {
+        state = { ...state, arrowColor: arrowColorInput.value }
         syncUi()
     })
 
@@ -1131,7 +1532,8 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         el === rulerCatcher ||
         [...wrapperLocks.values()].some(b => b === el) ||
         [...guideEls.values()].some(g => g === el) ||
-        [...rulerEls.values()].some(c => c === el || c.contains(el))
+        [...rulerEls.values()].some(c => c === el || c.contains(el)) ||
+        [...arrowEls.values()].some(c => c === el || c.contains(el))
 
     const describeEl = (el: Element): string => {
         const r = el.getBoundingClientRect()
@@ -1347,8 +1749,10 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         else if (act === 'addGuideV') { addGuide('x') }
         else if (act === 'addGuideH') { addGuide('y') }
         else if (act === 'clearGuides') { state = { ...state, guides: [] }; renderGuides(); save() }
-        else if (act === 'ruler') { setRulerArmed(!rulerArmed) }
+        else if (act === 'ruler') { setArmed(rulerArmed === 'ruler' ? null : 'ruler') }
         else if (act === 'clearRulers') { state = { ...state, rulers: [] }; renderRulers(); save() }
+        else if (act === 'arrow') { setArmed(rulerArmed === 'arrow' ? null : 'arrow') }
+        else if (act === 'clearArrows') { state = { ...state, arrows: [] }; renderArrows(); save() }
         else if (act === 'fit') {
             if (preFit) {
                 // Second click: un-fit, restoring the size/position from before.
@@ -1411,13 +1815,16 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         // Esc exits pick mode; a second Esc (or Esc when not picking) clears
         // any locked highlights. Allowed even when a field is focused.
         if (e.key === 'Escape') {
-            if (rulerArmed) { e.preventDefault(); setRulerArmed(false); return }
+            if (rulerArmed) { e.preventDefault(); setArmed(null); return }
             if (pickActive) { e.preventDefault(); setPickActive(false); return }
             if (totalLocks() > 0) { e.preventDefault(); clearAllLocks(); return }
         }
         const tgt = e.target as HTMLElement | null
-        if (tgt && /^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName)) return
-        // Delete/Backspace removes the guide or ruler the pointer is hovering.
+        // isContentEditable covers the arrow labels: without it, typing a
+        // caption would nudge the overlay and Delete would erase the arrow
+        // mid-sentence.
+        if (tgt && (/^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName) || tgt.isContentEditable)) return
+        // Delete/Backspace removes the guide, ruler or arrow the pointer is on.
         if ((e.key === 'Delete' || e.key === 'Backspace') && hoveredGuideId) {
             e.preventDefault()
             removeGuide(hoveredGuideId)
@@ -1426,6 +1833,11 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         if ((e.key === 'Delete' || e.key === 'Backspace') && hoveredRulerId) {
             e.preventDefault()
             removeRuler(hoveredRulerId)
+            return
+        }
+        if ((e.key === 'Delete' || e.key === 'Backspace') && hoveredArrowId) {
+            e.preventDefault()
+            removeArrow(hoveredArrowId)
             return
         }
         const step = e.shiftKey ? 10 : 1
@@ -1444,7 +1856,9 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
     // normal text paste still works there.
     window.addEventListener('paste', (e: ClipboardEvent) => {
         const tgt = e.target as HTMLElement | null
-        if (tgt && /^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName)) return
+        // isContentEditable: pasting text into an arrow label must stay a text
+        // paste, not load the clipboard as the overlay image.
+        if (tgt && (/^(INPUT|TEXTAREA|SELECT)$/.test(tgt.tagName) || tgt.isContentEditable)) return
         if (loadFromDataTransfer(e.clipboardData)) e.preventDefault()
     })
 

--- a/dev-wrapper/visualDiffOverlay.ts
+++ b/dev-wrapper/visualDiffOverlay.ts
@@ -968,12 +968,12 @@ export const mountVisualDiffOverlay = (opts: { startExpanded?: boolean } = {}) =
         <div data-el="body">
         <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
             <span style="width:56px;color:#9aa0a6">Figma</span>
-            <input type="text" data-el="figma" placeholder="figma.com/design/…?node-id=…" style="flex:1;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+            <input type="text" data-el="figma" placeholder="figma.com/design/…?node-id=…" style="flex:1;min-width:0;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
             <button data-act="fetchFigma" style="background:#2a2d33;color:#F5F8FF;border:0;padding:4px 8px;border-radius:4px;cursor:pointer;font:inherit">load</button>
         </div>
         <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
             <span style="width:56px;color:#9aa0a6">Token</span>
-            <input type="password" data-el="figmaToken" placeholder="Figma token (stored in this browser only)" autocomplete="off" style="flex:1;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
+            <input type="password" data-el="figmaToken" placeholder="Figma token (stored in this browser only)" autocomplete="off" style="flex:1;min-width:0;background:#0e1116;color:#F5F8FF;border:1px solid #2a2d33;padding:2px 4px;border-radius:4px;font:inherit">
         </div>
         <div data-el="figmaStatus" style="margin-top:4px;color:#9aa0a6;font-size:11px;min-height:14px"></div>
         <div style="display:flex;align-items:center;gap:6px;margin-top:6px">

--- a/public/DEFAULT/mobile/translations/en.json
+++ b/public/DEFAULT/mobile/translations/en.json
@@ -1,5 +1,8 @@
 {
     "title": "Cashback",
+    "coupons": "Coupons",
+    "cashback": "Cashback",
+    "connectYourWallet": "Connect your wallet",
     "back": "Back",
     "rewards": "Rewards",
     "claimable": "Claimable",

--- a/public/SOLFLARE/mobile/stylesheets/dark.css
+++ b/public/SOLFLARE/mobile/stylesheets/dark.css
@@ -45,6 +45,21 @@
     --bg: #090C11;
     --scrollbar-w: 12px;
     --scrollbar-bg: #282B30;
+    /* Component CSS modules pick this up over their 'Prompt' fallback. */
+    --font-family: 'FK Grotesk', system-ui, -apple-system, sans-serif;
+
+    /* ── Coupons / Cashback switcher (Figma tab-switcher 278:4725) ── */
+    --coupons-toggle-bg: #1B1E23;
+    --coupons-toggle-radius: 8px;
+    --coupons-toggle-f-c: #7A7D83;
+    --coupons-toggle-f-s: 12px;
+    --coupons-toggle-f-w: 500;
+    --coupons-toggle-l-h: 16px;
+    --coupons-toggle-hover-f-c: #F5F8FF;
+    --coupons-toggle-hover-bg: rgba(245, 245, 245, 0.05);
+    --coupons-toggle-active-bg: #FFEF46;
+    --coupons-toggle-active-f-c: #1F2018;
+    --coupons-toggle-active-radius: 8px;
 
     /* ── Hero "Cashback earned" card — flat status-card look (Figma
        "pending"/"claim" cards): #12151A + hairline border (via shadow token,

--- a/src/api/fetchToken.ts
+++ b/src/api/fetchToken.ts
@@ -24,6 +24,9 @@ interface Response {
         walletName?: string
         bringTou?: string
         privacy?: string
+        // Coupons iframe URL (mobile-only feature); absent when the wallet
+        // isn't connected or the platform has no coupons integration.
+        couponsIframeSrc?: string
     }
 }
 

--- a/src/components/CashbackEarned/styles.mobile.module.css
+++ b/src/components/CashbackEarned/styles.mobile.module.css
@@ -85,7 +85,7 @@
 .label {
     margin: 0;
     color: var(--cashback-earned-label-f-c, #AFBBFF);
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     font-size: var(--cashback-earned-label-f-s, 14px);
     font-weight: var(--cashback-earned-label-f-w, 400);
     line-height: var(--cashback-earned-label-l-h, 20px);
@@ -98,7 +98,7 @@
     display: flex;
     align-items: center;
     color: var(--cashback-earned-amount-f-c, #F7F7F7);
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     font-size: var(--cashback-earned-amount-f-s, 24px);
     font-weight: var(--cashback-earned-amount-f-w, 700);
     line-height: var(--cashback-earned-amount-l-h, 24px);
@@ -108,7 +108,7 @@
 .sub {
     margin: 0;
     color: var(--cashback-earned-sub-f-c, #8793FF);
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     font-size: var(--cashback-earned-sub-f-s, 12px);
     font-weight: var(--cashback-earned-sub-f-w, 400);
     line-height: var(--cashback-earned-sub-l-h, 16px);

--- a/src/components/Categories/styles.mobile.module.css
+++ b/src/components/Categories/styles.mobile.module.css
@@ -61,7 +61,7 @@
     border-radius: var(--tab-radius, 6px);
     background: var(--tab-bg, transparent);
     color: var(--tab-f-c, #7685A0);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--tab-f-s, 14px);
     font-weight: var(--tab-f-w, 400);
     line-height: var(--tab-l-h, 20px);

--- a/src/components/CouponsConnect/CouponsConnect.mobile.tsx
+++ b/src/components/CouponsConnect/CouponsConnect.mobile.tsx
@@ -1,0 +1,51 @@
+/**
+ * Disconnected-state screen for the Coupons view: "connect to unlock" promo.
+ *
+ * PLACEHOLDER: there is no design/spec for this screen yet - this whole
+ * component (markup, styles, copy) is disposable and should be replaced
+ * wholesale when the final design lands. Copy is hard-coded on purpose (not
+ * in the translation files) so deleting the component leaves nothing behind.
+ * The only contract to keep: the button posts the LOGIN action (same as the
+ * desktop LoginModal) so the host wallet opens its connect flow.
+ */
+import { useTranslation } from 'react-i18next'
+import message from '../../utils/message'
+import styles from './styles.mobile.module.css'
+
+const CouponsConnect = () => {
+    const { t } = useTranslation()
+
+    return (
+        <div className={styles.root}>
+            <div className={styles.glow} aria-hidden="true" />
+            <div className={styles.promo}>
+                <span className={`${styles.chip} ${styles.chipA}`} aria-hidden="true">%</span>
+                <span className={`${styles.chip} ${styles.chipB}`} aria-hidden="true">$</span>
+                <div className={styles.ticketStack} aria-hidden="true">
+                    <div className={styles.couponBack} />
+                    <div className={styles.coupon}>
+                        <span className={styles.couponPct}>%</span>
+                        <span className={styles.couponDivider} />
+                        <span className={styles.couponText}>Exclusive deals</span>
+                    </div>
+                </div>
+                <h3 className={styles.title}>Stop paying full price</h3>
+                <p className={styles.sub}>
+                    Verified promo codes and instant discounts from top brands.
+                    Real savings on shopping you'd do anyway. Connect once and
+                    it's all yours.
+                </p>
+                <button
+                    type="button"
+                    className={styles.connectBtn}
+                    onClick={() => message({ action: 'LOGIN' })}
+                >
+                    {t('connectYourWallet')}
+                </button>
+                <p className={styles.hint}>Takes seconds.</p>
+            </div>
+        </div>
+    )
+}
+
+export default CouponsConnect

--- a/src/components/CouponsConnect/styles.mobile.module.css
+++ b/src/components/CouponsConnect/styles.mobile.module.css
@@ -1,0 +1,223 @@
+/* Coupons "connect to unlock" promo.
+   PLACEHOLDER: no design/spec yet — disposable, replace wholesale with the
+   final design. Themed entirely off existing platform vars (accent = the
+   balance claim button) so each wallet gets its own colors for free. */
+.root {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 16px;
+    overflow: hidden;
+}
+
+/* Soft ambient accent glow behind everything. */
+.glow {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at 50% 38%, rgba(96, 103, 249, 0.18), transparent 62%);
+    background: radial-gradient(
+        circle at 50% 38%,
+        color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 20%, transparent),
+        transparent 62%
+    );
+}
+
+.promo {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    max-width: 300px;
+    text-align: center;
+}
+
+/* Floating deal chips drifting around the ticket. */
+.chip {
+    position: absolute;
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--balance-claim-btn-bg, #6067F9);
+    background: rgba(96, 103, 249, 0.14);
+    background: color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 14%, transparent);
+    border: 1px solid rgba(96, 103, 249, 0.35);
+    border-color: color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 35%, transparent);
+    animation: float 5s ease-in-out infinite;
+}
+
+/* Kept inside the promo bounds so the container never clips them. */
+.chipA { top: -34px; left: 6px; rotate: -12deg; }
+.chipB { top: 6px; right: -14px; rotate: 10deg; animation-delay: 1.3s; }
+
+/* Ticket stack: a second ticket peeking out behind the main one for depth. */
+.ticketStack {
+    position: relative;
+    margin-bottom: 14px;
+    animation: rise 0.5s ease-out both;
+}
+
+.couponBack {
+    position: absolute;
+    inset: 0;
+    border-radius: 14px;
+    rotate: 4deg;
+    translate: 6px 6px;
+    scale: 0.98;
+    opacity: 0.5;
+    background: #2b2f8a;
+    background: color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 45%, #000);
+}
+
+/* The coupon ticket: accent gradient, perforation notches, dashed tear line. */
+.coupon {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 22px;
+    rotate: -3deg;
+    border-radius: 14px;
+    background: linear-gradient(135deg, var(--balance-claim-btn-bg, #6067F9), #3a3f9e);
+    background: linear-gradient(
+        135deg,
+        var(--balance-claim-btn-bg, #6067F9),
+        color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 58%, #000)
+    );
+    color: var(--balance-claim-btn-f-c, #F7F7F7);
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    box-shadow: 0 12px 32px rgba(96, 103, 249, 0.35);
+    box-shadow: 0 12px 32px color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 35%, transparent);
+    animation: bob 4.5s ease-in-out infinite;
+}
+
+/* Perforation notches punched out of the ticket's sides. */
+.coupon::before,
+.coupon::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--bg, #090C11);
+    transform: translateY(-50%);
+}
+
+.coupon::before { left: -7px; }
+.coupon::after { right: -7px; }
+
+.couponPct { font-size: 20px; line-height: 1; }
+
+.couponDivider {
+    align-self: stretch;
+    border-left: 2px dashed rgba(255, 255, 255, 0.45);
+}
+
+.title {
+    margin: 0;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 26px;
+    color: var(--balance-amount-f-c, #F5F8FF);
+    animation: rise 0.5s ease-out 0.08s both;
+}
+
+.sub {
+    margin: 0 0 10px;
+    color: var(--history-empty-f-c, #B1B4BB);
+    font-size: var(--history-empty-f-s, 14px);
+    font-weight: var(--history-empty-f-w, 400);
+    line-height: var(--history-empty-l-h, 20px);
+    animation: rise 0.5s ease-out 0.16s both;
+}
+
+/* Connect CTA — accent-themed, with a periodic sheen sweep. */
+.connectBtn {
+    position: relative;
+    overflow: hidden;
+    border: none;
+    padding: 12px 36px;
+    border-radius: var(--balance-claim-btn-radius, 10px);
+    background: var(--balance-claim-btn-bg, #6067F9);
+    color: var(--balance-claim-btn-f-c, #F7F7F7);
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 20px;
+    cursor: pointer;
+    box-shadow: 0 8px 24px rgba(96, 103, 249, 0.4);
+    box-shadow: 0 8px 24px color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 40%, transparent);
+    transition: transform 0.12s ease;
+    animation: rise 0.5s ease-out 0.24s both;
+}
+
+.connectBtn:active { transform: scale(0.97); }
+
+/* Trust microcopy under the CTA. */
+.hint {
+    margin: 0;
+    font-size: 12px;
+    line-height: 16px;
+    color: var(--history-empty-f-c, #B1B4BB);
+    opacity: 0.75;
+    animation: rise 0.5s ease-out 0.32s both;
+}
+
+.connectBtn::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -60%;
+    width: 40%;
+    background: linear-gradient(105deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+    animation: sheen 3s ease-in-out infinite;
+}
+
+@keyframes float {
+    0%, 100% { translate: 0 0; }
+    50% { translate: 0 -8px; }
+}
+
+@keyframes bob {
+    0%, 100% { translate: 0 0; rotate: -3deg; }
+    50% { translate: 0 -6px; rotate: -1.5deg; }
+}
+
+@keyframes sheen {
+    0%, 55% { left: -60%; }
+    85%, 100% { left: 120%; }
+}
+
+/* Staggered entrance for the stack → title → sub → CTA → hint. */
+@keyframes rise {
+    from { opacity: 0; translate: 0 14px; }
+    to { opacity: 1; translate: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .chip,
+    .coupon,
+    .connectBtn::after,
+    .ticketStack,
+    .title,
+    .sub,
+    .connectBtn,
+    .hint {
+        animation: none;
+    }
+}

--- a/src/components/CouponsToggle/CouponsToggle.mobile.tsx
+++ b/src/components/CouponsToggle/CouponsToggle.mobile.tsx
@@ -25,13 +25,12 @@ const CouponsToggle = ({ value, onChange }: Props) => {
     ]
 
     return (
-        <div className={styles.root} role="tablist" aria-orientation="vertical">
+        <div className={styles.root}>
             {options.map(({ key, label }) => (
                 <button
                     key={key}
                     type="button"
-                    role="tab"
-                    aria-selected={value === key}
+                    aria-pressed={value === key}
                     className={`${styles.option} ${value === key ? styles.optionActive : ''}`}
                     onClick={() => onChange(key)}
                 >

--- a/src/components/CouponsToggle/CouponsToggle.mobile.tsx
+++ b/src/components/CouponsToggle/CouponsToggle.mobile.tsx
@@ -1,0 +1,45 @@
+/**
+ * Coupons / Cashback vertical switcher (Figma "tab-switcher", node 278:4725).
+ * Mobile-only; rendered only when the verify response provides
+ * couponsIframeSrc. "Cashback" shows the regular offers; "Coupons" swaps the
+ * page content for the partner's coupons iframe.
+ *
+ * PLACEHOLDER for now — the final design/spec for this switcher is still
+ * pending; expect markup and styles to be replaced when it lands.
+ */
+import { useTranslation } from 'react-i18next'
+import styles from './styles.mobile.module.css'
+
+export type PortalView = 'coupons' | 'cashback'
+
+interface Props {
+    value: PortalView
+    onChange: (view: PortalView) => void
+}
+
+const CouponsToggle = ({ value, onChange }: Props) => {
+    const { t } = useTranslation()
+    const options: { key: PortalView; label: string }[] = [
+        { key: 'coupons', label: t('coupons') },
+        { key: 'cashback', label: t('cashback') },
+    ]
+
+    return (
+        <div className={styles.root} role="tablist" aria-orientation="vertical">
+            {options.map(({ key, label }) => (
+                <button
+                    key={key}
+                    type="button"
+                    role="tab"
+                    aria-selected={value === key}
+                    className={`${styles.option} ${value === key ? styles.optionActive : ''}`}
+                    onClick={() => onChange(key)}
+                >
+                    {label}
+                </button>
+            ))}
+        </div>
+    )
+}
+
+export default CouponsToggle

--- a/src/components/CouponsToggle/styles.mobile.module.css
+++ b/src/components/CouponsToggle/styles.mobile.module.css
@@ -1,0 +1,48 @@
+/* Coupons / Cashback switcher. Visuals driven by CSS vars with neutral
+   fallbacks; selected option is a filled chip, the other is plain text.
+
+   PLACEHOLDER for now — the final design/spec for this switcher is still
+   pending; expect these styles to be replaced when it lands. */
+
+.root {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px;
+    align-self: flex-start;
+    box-sizing: border-box;
+    min-width: 90px;
+    border-radius: var(--coupons-toggle-radius, 8px);
+    background: var(--coupons-toggle-bg, #1E293B);
+}
+
+.option {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 10px;
+    height: 16px;
+    border: none;
+    border-radius: var(--coupons-toggle-active-radius, 8px);
+    background: transparent;
+    color: var(--coupons-toggle-f-c, #94A3B8);
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
+    font-size: var(--coupons-toggle-f-s, 12px);
+    font-weight: var(--coupons-toggle-f-w, 500);
+    line-height: var(--coupons-toggle-l-h, 16px);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.option:hover:not(.optionActive) {
+    color: var(--coupons-toggle-hover-f-c, var(--coupons-toggle-f-c, #94A3B8));
+    background: var(--coupons-toggle-hover-bg, rgba(245, 245, 245, 0.05));
+}
+
+.optionActive {
+    height: 30px;
+    background: var(--coupons-toggle-active-bg, #06B6D4);
+    color: var(--coupons-toggle-active-f-c, #F8FAFC);
+    cursor: default;
+}

--- a/src/components/FaqItem/styles.mobile.module.css
+++ b/src/components/FaqItem/styles.mobile.module.css
@@ -34,7 +34,7 @@
     cursor: pointer;
     text-align: left;
     color: inherit;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
 }
 
 .questionText {
@@ -88,7 +88,7 @@
 
 .answerLine {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--faq-answer-f-s, 12px);
     font-weight: var(--faq-answer-f-w, 400);
     line-height: var(--faq-answer-l-h, 16px);

--- a/src/components/FilterChip/styles.mobile.module.css
+++ b/src/components/FilterChip/styles.mobile.module.css
@@ -16,7 +16,7 @@
     border-radius: var(--filter-chip-radius, 4px);
     background: var(--filter-chip-bg, rgba(62, 72, 100, 0.50));
     color: var(--filter-chip-f-c, #F7F7F7);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--filter-chip-f-s, 14px);
     font-weight: 400;
     line-height: var(--filter-chip-l-h, 20px);

--- a/src/components/HistoryItem/styles.mobile.module.css
+++ b/src/components/HistoryItem/styles.mobile.module.css
@@ -34,7 +34,7 @@
     cursor: pointer;
     text-align: left;
     color: inherit;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     min-height: 40px;
 }
 
@@ -214,7 +214,7 @@
 
 .descriptionLine {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--history-description-f-s, 12px);
     font-weight: var(--history-description-f-w, 400);
     line-height: var(--history-description-l-h, 16px);

--- a/src/components/RetailerCard/styles.mobile.module.css
+++ b/src/components/RetailerCard/styles.mobile.module.css
@@ -13,7 +13,7 @@
     box-sizing: border-box;
     cursor: pointer;
     text-align: left;
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     transition: background 0.15s ease;
 }
 

--- a/src/components/RetailerCardModal/styles.mobile.module.css
+++ b/src/components/RetailerCardModal/styles.mobile.module.css
@@ -33,7 +33,7 @@
     flex-direction: column;
     gap: 8px;
     overflow: hidden;
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
 }
 
 /* ── Header (Cashback Details + X) ───────────────────────────────── */

--- a/src/components/Rewards/styles.mobile.module.css
+++ b/src/components/Rewards/styles.mobile.module.css
@@ -73,7 +73,7 @@
 
 .label {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--balance-label-f-s, 12px);
     font-weight: var(--balance-label-f-w, 400);
     line-height: var(--balance-label-l-h, 16px);
@@ -89,7 +89,7 @@
 }
 
 .amount {
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--balance-amount-f-s, 16px);
     font-weight: var(--balance-amount-f-w, 700);
     line-height: var(--balance-amount-l-h, 22px);
@@ -113,7 +113,7 @@
     border-radius: var(--balance-claim-btn-radius, 4px);
     background: var(--balance-claim-btn-bg, #6067F9);
     color: var(--balance-claim-btn-f-c, #F7F7F7);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--balance-claim-btn-f-s, 12px);
     font-weight: var(--balance-claim-btn-f-w, 400);
     line-height: 16px;
@@ -187,7 +187,7 @@
     border-radius: var(--helper-btn-radius, 4px);
     background: var(--helper-btn-bg, #2B344D);
     color: var(--helper-btn-f-c, #F7F7F7);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--helper-btn-f-s, 12px);
     font-weight: var(--helper-btn-f-w, 400);
     line-height: 16px;

--- a/src/context/WalletAddressContext.tsx
+++ b/src/context/WalletAddressContext.tsx
@@ -8,10 +8,15 @@ interface WalletContextType {
     isTester: boolean
     walletAddress: string | null;
     setWalletAddress: (address: string) => void;
-    /** Wallet display name — from the JWT (verify) or dev URL params. */
+    /** Wallet display name - from the JWT (verify) or dev URL params. */
     walletName?: string;
-    /** Wallet emoji asset URL — from the JWT (verify) or dev URL params. */
+    /** Wallet emoji asset URL - from the JWT (verify) or dev URL params. */
     walletEmoji?: string;
+    /** Coupons iframe URL - refreshed wholesale on every SESSION_UPDATE
+     *  verify: absent in the new response means absent here (unlike
+     *  walletName/Emoji it does NOT keep the stale value, so the UI can
+     *  fall back to its connect placeholder). */
+    couponsIframeSrc?: string;
 }
 
 export const WalletContext = createContext<WalletContextType | undefined>(undefined);
@@ -22,6 +27,7 @@ export function WalletProvider({
     initIsTester,
     initialWalletName,
     initialWalletEmoji,
+    initialCouponsIframeSrc,
     mode = 'desktop',
 }: {
     children: ReactNode,
@@ -29,7 +35,8 @@ export function WalletProvider({
     initIsTester: boolean,
     initialWalletName?: string,
     initialWalletEmoji?: string,
-    // Current portal mode — preserved when a SESSION_UPDATE re-themes, so the
+    initialCouponsIframeSrc?: string,
+    // Current portal mode - preserved when a SESSION_UPDATE re-themes, so the
     // mobile stylesheet tags aren't stripped by a default 'desktop' call.
     mode?: StylesheetMode,
 }) {
@@ -40,6 +47,7 @@ export function WalletProvider({
     // wallet switch updates the name/emoji without a full reload.
     const [walletName, setWalletName] = useState<string | undefined>(initialWalletName)
     const [walletEmoji, setWalletEmoji] = useState<string | undefined>(initialWalletEmoji)
+    const [couponsIframeSrc, setCouponsIframeSrc] = useState<string | undefined>(initialCouponsIframeSrc)
 
     useEffect(() => {
         const handleMessage = async (event: MessageEvent) => {
@@ -56,10 +64,13 @@ export function WalletProvider({
                     setWalletAddress(res.info.walletAddress || null)
                     setIsTester(!!res.info.isTester && ENV !== 'prod')
                     // Only overwrite when the new token actually carries the
-                    // field — otherwise keep the value seeded from the loader
+                    // field - otherwise keep the value seeded from the loader
                     // (e.g. dev URL params the JWT doesn't echo).
                     if (res.info.walletName) setWalletName(res.info.walletName)
                     if (res.info.walletEmoji) setWalletEmoji(res.info.walletEmoji)
+                    // Replace, don't merge: a verify without couponsIframeSrc
+                    // (e.g. wallet disconnected) must clear the stale URL.
+                    setCouponsIframeSrc(res.info.couponsIframeSrc || undefined)
                     if (res.info.theme) {
                         loadStylesheet(res.info.theme.toLowerCase(), res.info.platform || 'DEFAULT', mode)
                     }
@@ -78,7 +89,7 @@ export function WalletProvider({
     }, [mode])
 
     return (
-        <WalletContext.Provider value={{ isTester, walletAddress, setWalletAddress, walletName, walletEmoji }}>
+        <WalletContext.Provider value={{ isTester, walletAddress, setWalletAddress, walletName, walletEmoji, couponsIframeSrc }}>
             {children}
         </WalletContext.Provider>
     );

--- a/src/context/WalletAddressContext.tsx
+++ b/src/context/WalletAddressContext.tsx
@@ -51,6 +51,15 @@ export function WalletProvider({
 
     useEffect(() => {
         const handleMessage = async (event: MessageEvent) => {
+            // Only the embedding host page may drive the session. When the
+            // portal is embedded, the host is `window.parent`; anything else -
+            // the nested coupons iframe (its messages arrive with `source` set
+            // to that iframe's window), wallet-extension content scripts
+            // posting to this window (`source === window`), or any other
+            // frame — must not be able to swap the session or re-theme the
+            // portal. When the portal runs top-level, `window.parent` is the
+            // window itself, so dev/console posts still work.
+            if (event.source !== window.parent) return
             const data = event.data
             // Validate message shape before trusting the payload.
             if (!data || typeof data !== 'object') return

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -30,6 +30,7 @@ const Layout = () => {
             initIsTester={data.isTester}
             initialWalletName={data.walletName}
             initialWalletEmoji={data.walletEmoji}
+            initialCouponsIframeSrc={data.couponsIframeSrc}
             mode={data.useMobilePortal ? 'mobile' : 'desktop'}
         >
             <AnalyticsProvider

--- a/src/pages/FrequentlyAskedQuestion/styles.mobile.module.css
+++ b/src/pages/FrequentlyAskedQuestion/styles.mobile.module.css
@@ -80,7 +80,7 @@
 
 .intro {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--faq-intro-f-s, 14px);
     font-weight: var(--faq-intro-f-w, 400);
     line-height: var(--faq-intro-l-h, 20px);

--- a/src/pages/History/styles.mobile.module.css
+++ b/src/pages/History/styles.mobile.module.css
@@ -95,7 +95,7 @@
 .intro {
     margin: 0;
     padding: 0 16px;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--history-intro-f-s, 12px);
     font-weight: var(--history-intro-f-w, 400);
     line-height: var(--history-intro-l-h, 16px);
@@ -175,7 +175,7 @@
 
 .emptyText {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--history-empty-f-s, 14px);
     font-weight: var(--history-empty-f-w, 400);
     line-height: var(--history-empty-l-h, 20px);

--- a/src/pages/Home/Home.mobile.tsx
+++ b/src/pages/Home/Home.mobile.tsx
@@ -1,15 +1,29 @@
 /** Mobile portal home page: hero + filter row (categories / search / chip) +
  * retailer list + claim modal. Pure UI — logic in useHomePage. */
+import { useState } from 'react'
+import { useRouteLoaderData } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import MobileHeroSection from '../../components/HeroSection/HeroSection.mobile'
 import MobileCategories from '../../components/Categories/Categories.mobile'
 import MobileSearchBar from '../../components/Search/Search.mobile'
 import MobileFilterChip from '../../components/FilterChip/FilterChip.mobile'
 import MobileCardsList from '../../components/CardsList/CardsList.mobile'
 import MobileClaimModal from '../../components/ClaimModal/ClaimModal.mobile'
+import MobileCouponsToggle, { PortalView } from '../../components/CouponsToggle/CouponsToggle.mobile'
+import MobileCouponsConnect from '../../components/CouponsConnect/CouponsConnect.mobile'
 import { useHomePage } from './useHomePage'
 import styles from './styles.mobile.module.css'
 
 const MobileHome = () => {
+    // Coupons/Cashback switcher - the feature is enabled when verify returned
+    // couponsIframeSrc (initially via the loader, or later via SESSION_UPDATE;
+    // mobile-only by construction: this page renders only on mobile). The live
+    // src comes from the wallet context so each new verify replaces it; the
+    // iframe mounts only with a connected wallet AND a current src - otherwise
+    // the Coupons view shows a connect placeholder.
+    const { couponsIframeSrc: initialCouponsIframeSrc } = useRouteLoaderData('root') as LoaderData
+    const { t } = useTranslation()
+    const [view, setView] = useState<PortalView>('cashback')
     const {
         category,
         setCategory,
@@ -45,7 +59,11 @@ const MobileHome = () => {
         handleOpenClaim,
         handleCloseClaim,
         handleConfirmClaim,
+        couponsIframeSrc,
     } = useHomePage()
+
+    const couponsEnabled = Boolean(initialCouponsIframeSrc || couponsIframeSrc)
+    const showCoupons = couponsEnabled && view === 'coupons'
 
     // Decide what occupies the tabs-row slot. Priority: open input >
     // committed search chip > category chip > full categories row.
@@ -83,17 +101,34 @@ const MobileHome = () => {
     return (
         <div className={styles.root} data-testid="mobile-home">
             <main className={styles.content}>
-                <MobileHeroSection onClaim={handleOpenClaim} />
-                {renderFilterRow()}
-                <MobileCardsList
-                    retailers={retailers}
-                    metadata={metadata}
-                    isLoading={isLoadingRetailers}
-                    isFetchingNextPage={isFetchingNextPage}
-                    hasNextPage={Boolean(hasNextPage)}
-                    onFetchNextPage={fetchNextPage}
-                    isSearching={isSearching}
-                />
+                {couponsEnabled && (
+                    <MobileCouponsToggle value={view} onChange={setView} />
+                )}
+                {showCoupons ? (
+                    walletAddress && couponsIframeSrc ? (
+                        <iframe
+                            className={styles.couponsFrame}
+                            src={couponsIframeSrc}
+                            title={t('coupons')}
+                        />
+                    ) : (
+                        <MobileCouponsConnect />
+                    )
+                ) : (
+                    <>
+                        <MobileHeroSection onClaim={handleOpenClaim} />
+                        {renderFilterRow()}
+                        <MobileCardsList
+                            retailers={retailers}
+                            metadata={metadata}
+                            isLoading={isLoadingRetailers}
+                            isFetchingNextPage={isFetchingNextPage}
+                            hasNextPage={Boolean(hasNextPage)}
+                            onFetchNextPage={fetchNextPage}
+                            isSearching={isSearching}
+                        />
+                    </>
+                )}
             </main>
             <MobileClaimModal
                 state={claimState}

--- a/src/pages/Home/styles.mobile.module.css
+++ b/src/pages/Home/styles.mobile.module.css
@@ -26,3 +26,15 @@
 .content > *:not(:last-child) {
     flex-shrink: 0;
 }
+
+/* Coupons view — the partner iframe fills the space below the switcher,
+   full-bleed: cancel the content gutter so the coupons page runs
+   edge-to-edge and down to the bottom (Figma 278:4832). */
+.couponsFrame {
+    flex: 1 1 auto;
+    min-height: 0;
+    margin: 0 -16px -16px;
+    border: 0;
+    display: block;
+    background: var(--bg);
+}

--- a/src/pages/Home/useHomePage.ts
+++ b/src/pages/Home/useHomePage.ts
@@ -23,7 +23,7 @@ const SEARCH_MIN_CHARS = 2
 
 export const useHomePage = () => {
     const { platform, userId, flowId, cryptoSymbols } = useRouteLoaderData('root') as LoaderData
-    const { walletAddress, walletName, walletEmoji } = useWalletAddress()
+    const { walletAddress, walletName, walletEmoji, couponsIframeSrc } = useWalletAddress()
     const queryClient = useQueryClient()
 
     const [category, setCategory] = useState<CategoriesItem | null>(null)
@@ -241,5 +241,7 @@ export const useHomePage = () => {
         handleOpenClaim,
         handleCloseClaim,
         handleConfirmClaim,
+        // coupons - live value from the wallet context (refreshed per verify)
+        couponsIframeSrc,
     }
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -89,6 +89,7 @@ const rootLoader = async () => {
             walletEmoji: params.get('walletEmoji') || undefined,
             bringTou: params.get('bringTou') || undefined,
             privacy: params.get('privacy') || undefined,
+            couponsIframeSrc: params.get('couponsIframeSrc') || undefined,
         }
         if (!dev.platform) throw Error('Missing platform')
         const devPlatform = dev.platform.toUpperCase()

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -50,6 +50,10 @@ interface LoaderData {
     walletEmoji?: string
     walletName?: string
     useMobilePortal?: boolean
+    // Coupons iframe URL from verify. When present (mobile only) the portal
+    // shows a Coupons/Cashback switcher and embeds this src on Coupons;
+    // desktop ignores it and stays cashback-only.
+    couponsIframeSrc?: string
     variant: string
     bringTou?: string
     privacy?: string


### PR DESCRIPTION
- Plumb couponsIframeSrc from verify through loader/context into MobileHome
- Coupons/Cashback switcher (CouponsToggle) shown when the platform has coupons
- Placeholder CouponsConnect screen prompting wallet connect (LOGIN action)
- Solflare dark-theme vars for the new coupons UI
- dev-wrapper: device presets with rotate, VITE_PORTAL_VIEW_MODE default, devicePlatform hint sent to check/portal for platform-sensitive iframes