### PR TITLE
Mobile coupons

### DIFF
--- a/public/DEFAULT/mobile/translations/en.json
+++ b/public/DEFAULT/mobile/translations/en.json
@@ -1,5 +1,8 @@
 {
     "title": "Cashback",
+    "coupons": "Coupons",
+    "cashback": "Cashback",
+    "connectYourWallet": "Connect your wallet",
     "back": "Back",
     "rewards": "Rewards",
     "claimable": "Claimable",

--- a/public/SOLFLARE/mobile/stylesheets/dark.css
+++ b/public/SOLFLARE/mobile/stylesheets/dark.css
@@ -45,6 +45,21 @@
     --bg: #090C11;
     --scrollbar-w: 12px;
     --scrollbar-bg: #282B30;
+    /* Component CSS modules pick this up over their 'Prompt' fallback. */
+    --font-family: 'FK Grotesk', system-ui, -apple-system, sans-serif;
+
+    /* ── Coupons / Cashback switcher (Figma tab-switcher 278:4725) ── */
+    --coupons-toggle-bg: #1B1E23;
+    --coupons-toggle-radius: 8px;
+    --coupons-toggle-f-c: #7A7D83;
+    --coupons-toggle-f-s: 12px;
+    --coupons-toggle-f-w: 500;
+    --coupons-toggle-l-h: 16px;
+    --coupons-toggle-hover-f-c: #F5F8FF;
+    --coupons-toggle-hover-bg: rgba(245, 245, 245, 0.05);
+    --coupons-toggle-active-bg: #FFEF46;
+    --coupons-toggle-active-f-c: #1F2018;
+    --coupons-toggle-active-radius: 8px;
 
     /* ── Hero "Cashback earned" card — flat status-card look (Figma
        "pending"/"claim" cards): #12151A + hairline border (via shadow token,

--- a/src/api/fetchToken.ts
+++ b/src/api/fetchToken.ts
@@ -25,6 +25,9 @@ interface Response {
         walletName?: string
         bringTou?: string
         privacy?: string
+        // Coupons iframe URL (mobile-only feature); absent when the wallet
+        // isn't connected or the platform has no coupons integration.
+        couponsIframeSrc?: string
     }
 }
 

--- a/src/components/CashbackEarned/styles.mobile.module.css
+++ b/src/components/CashbackEarned/styles.mobile.module.css
@@ -85,7 +85,7 @@
 .label {
     margin: 0;
     color: var(--cashback-earned-label-f-c, #AFBBFF);
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     font-size: var(--cashback-earned-label-f-s, 14px);
     font-weight: var(--cashback-earned-label-f-w, 400);
     line-height: var(--cashback-earned-label-l-h, 20px);
@@ -98,7 +98,7 @@
     display: flex;
     align-items: center;
     color: var(--cashback-earned-amount-f-c, #F7F7F7);
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     font-size: var(--cashback-earned-amount-f-s, 24px);
     font-weight: var(--cashback-earned-amount-f-w, 700);
     line-height: var(--cashback-earned-amount-l-h, 24px);
@@ -108,7 +108,7 @@
 .sub {
     margin: 0;
     color: var(--cashback-earned-sub-f-c, #8793FF);
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     font-size: var(--cashback-earned-sub-f-s, 12px);
     font-weight: var(--cashback-earned-sub-f-w, 400);
     line-height: var(--cashback-earned-sub-l-h, 16px);

--- a/src/components/Categories/styles.mobile.module.css
+++ b/src/components/Categories/styles.mobile.module.css
@@ -61,7 +61,7 @@
     border-radius: var(--tab-radius, 6px);
     background: var(--tab-bg, transparent);
     color: var(--tab-f-c, #7685A0);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--tab-f-s, 14px);
     font-weight: var(--tab-f-w, 400);
     line-height: var(--tab-l-h, 20px);

--- a/src/components/CouponsConnect/CouponsConnect.mobile.tsx
+++ b/src/components/CouponsConnect/CouponsConnect.mobile.tsx
@@ -1,0 +1,51 @@
+/**
+ * Disconnected-state screen for the Coupons view: "connect to unlock" promo.
+ *
+ * PLACEHOLDER: there is no design/spec for this screen yet - this whole
+ * component (markup, styles, copy) is disposable and should be replaced
+ * wholesale when the final design lands. Copy is hard-coded on purpose (not
+ * in the translation files) so deleting the component leaves nothing behind.
+ * The only contract to keep: the button posts the LOGIN action (same as the
+ * desktop LoginModal) so the host wallet opens its connect flow.
+ */
+import { useTranslation } from 'react-i18next'
+import message from '../../utils/message'
+import styles from './styles.mobile.module.css'
+
+const CouponsConnect = () => {
+    const { t } = useTranslation()
+
+    return (
+        <div className={styles.root}>
+            <div className={styles.glow} aria-hidden="true" />
+            <div className={styles.promo}>
+                <span className={`${styles.chip} ${styles.chipA}`} aria-hidden="true">%</span>
+                <span className={`${styles.chip} ${styles.chipB}`} aria-hidden="true">$</span>
+                <div className={styles.ticketStack} aria-hidden="true">
+                    <div className={styles.couponBack} />
+                    <div className={styles.coupon}>
+                        <span className={styles.couponPct}>%</span>
+                        <span className={styles.couponDivider} />
+                        <span className={styles.couponText}>Exclusive deals</span>
+                    </div>
+                </div>
+                <h3 className={styles.title}>Stop paying full price</h3>
+                <p className={styles.sub}>
+                    Verified promo codes and instant discounts from top brands.
+                    Real savings on shopping you'd do anyway. Connect once and
+                    it's all yours.
+                </p>
+                <button
+                    type="button"
+                    className={styles.connectBtn}
+                    onClick={() => message({ action: 'LOGIN' })}
+                >
+                    {t('connectYourWallet')}
+                </button>
+                <p className={styles.hint}>Takes seconds.</p>
+            </div>
+        </div>
+    )
+}
+
+export default CouponsConnect

--- a/src/components/CouponsConnect/styles.mobile.module.css
+++ b/src/components/CouponsConnect/styles.mobile.module.css
@@ -1,0 +1,223 @@
+/* Coupons "connect to unlock" promo.
+   PLACEHOLDER: no design/spec yet — disposable, replace wholesale with the
+   final design. Themed entirely off existing platform vars (accent = the
+   balance claim button) so each wallet gets its own colors for free. */
+.root {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 16px;
+    overflow: hidden;
+}
+
+/* Soft ambient accent glow behind everything. */
+.glow {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at 50% 38%, rgba(96, 103, 249, 0.18), transparent 62%);
+    background: radial-gradient(
+        circle at 50% 38%,
+        color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 20%, transparent),
+        transparent 62%
+    );
+}
+
+.promo {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    max-width: 300px;
+    text-align: center;
+}
+
+/* Floating deal chips drifting around the ticket. */
+.chip {
+    position: absolute;
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--balance-claim-btn-bg, #6067F9);
+    background: rgba(96, 103, 249, 0.14);
+    background: color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 14%, transparent);
+    border: 1px solid rgba(96, 103, 249, 0.35);
+    border-color: color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 35%, transparent);
+    animation: float 5s ease-in-out infinite;
+}
+
+/* Kept inside the promo bounds so the container never clips them. */
+.chipA { top: -34px; left: 6px; rotate: -12deg; }
+.chipB { top: 6px; right: -14px; rotate: 10deg; animation-delay: 1.3s; }
+
+/* Ticket stack: a second ticket peeking out behind the main one for depth. */
+.ticketStack {
+    position: relative;
+    margin-bottom: 14px;
+    animation: rise 0.5s ease-out both;
+}
+
+.couponBack {
+    position: absolute;
+    inset: 0;
+    border-radius: 14px;
+    rotate: 4deg;
+    translate: 6px 6px;
+    scale: 0.98;
+    opacity: 0.5;
+    background: #2b2f8a;
+    background: color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 45%, #000);
+}
+
+/* The coupon ticket: accent gradient, perforation notches, dashed tear line. */
+.coupon {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 22px;
+    rotate: -3deg;
+    border-radius: 14px;
+    background: linear-gradient(135deg, var(--balance-claim-btn-bg, #6067F9), #3a3f9e);
+    background: linear-gradient(
+        135deg,
+        var(--balance-claim-btn-bg, #6067F9),
+        color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 58%, #000)
+    );
+    color: var(--balance-claim-btn-f-c, #F7F7F7);
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    box-shadow: 0 12px 32px rgba(96, 103, 249, 0.35);
+    box-shadow: 0 12px 32px color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 35%, transparent);
+    animation: bob 4.5s ease-in-out infinite;
+}
+
+/* Perforation notches punched out of the ticket's sides. */
+.coupon::before,
+.coupon::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--bg, #090C11);
+    transform: translateY(-50%);
+}
+
+.coupon::before { left: -7px; }
+.coupon::after { right: -7px; }
+
+.couponPct { font-size: 20px; line-height: 1; }
+
+.couponDivider {
+    align-self: stretch;
+    border-left: 2px dashed rgba(255, 255, 255, 0.45);
+}
+
+.title {
+    margin: 0;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 26px;
+    color: var(--balance-amount-f-c, #F5F8FF);
+    animation: rise 0.5s ease-out 0.08s both;
+}
+
+.sub {
+    margin: 0 0 10px;
+    color: var(--history-empty-f-c, #B1B4BB);
+    font-size: var(--history-empty-f-s, 14px);
+    font-weight: var(--history-empty-f-w, 400);
+    line-height: var(--history-empty-l-h, 20px);
+    animation: rise 0.5s ease-out 0.16s both;
+}
+
+/* Connect CTA — accent-themed, with a periodic sheen sweep. */
+.connectBtn {
+    position: relative;
+    overflow: hidden;
+    border: none;
+    padding: 12px 36px;
+    border-radius: var(--balance-claim-btn-radius, 10px);
+    background: var(--balance-claim-btn-bg, #6067F9);
+    color: var(--balance-claim-btn-f-c, #F7F7F7);
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 20px;
+    cursor: pointer;
+    box-shadow: 0 8px 24px rgba(96, 103, 249, 0.4);
+    box-shadow: 0 8px 24px color-mix(in srgb, var(--balance-claim-btn-bg, #6067F9) 40%, transparent);
+    transition: transform 0.12s ease;
+    animation: rise 0.5s ease-out 0.24s both;
+}
+
+.connectBtn:active { transform: scale(0.97); }
+
+/* Trust microcopy under the CTA. */
+.hint {
+    margin: 0;
+    font-size: 12px;
+    line-height: 16px;
+    color: var(--history-empty-f-c, #B1B4BB);
+    opacity: 0.75;
+    animation: rise 0.5s ease-out 0.32s both;
+}
+
+.connectBtn::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -60%;
+    width: 40%;
+    background: linear-gradient(105deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+    animation: sheen 3s ease-in-out infinite;
+}
+
+@keyframes float {
+    0%, 100% { translate: 0 0; }
+    50% { translate: 0 -8px; }
+}
+
+@keyframes bob {
+    0%, 100% { translate: 0 0; rotate: -3deg; }
+    50% { translate: 0 -6px; rotate: -1.5deg; }
+}
+
+@keyframes sheen {
+    0%, 55% { left: -60%; }
+    85%, 100% { left: 120%; }
+}
+
+/* Staggered entrance for the stack → title → sub → CTA → hint. */
+@keyframes rise {
+    from { opacity: 0; translate: 0 14px; }
+    to { opacity: 1; translate: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .chip,
+    .coupon,
+    .connectBtn::after,
+    .ticketStack,
+    .title,
+    .sub,
+    .connectBtn,
+    .hint {
+        animation: none;
+    }
+}

--- a/src/components/CouponsToggle/CouponsToggle.mobile.tsx
+++ b/src/components/CouponsToggle/CouponsToggle.mobile.tsx
@@ -25,13 +25,12 @@ const CouponsToggle = ({ value, onChange }: Props) => {
     ]
 
     return (
-        <div className={styles.root} role="tablist" aria-orientation="vertical">
+        <div className={styles.root}>
             {options.map(({ key, label }) => (
                 <button
                     key={key}
                     type="button"
-                    role="tab"
-                    aria-selected={value === key}
+                    aria-pressed={value === key}
                     className={`${styles.option} ${value === key ? styles.optionActive : ''}`}
                     onClick={() => onChange(key)}
                 >

--- a/src/components/CouponsToggle/CouponsToggle.mobile.tsx
+++ b/src/components/CouponsToggle/CouponsToggle.mobile.tsx
@@ -1,0 +1,45 @@
+/**
+ * Coupons / Cashback vertical switcher (Figma "tab-switcher", node 278:4725).
+ * Mobile-only; rendered only when the verify response provides
+ * couponsIframeSrc. "Cashback" shows the regular offers; "Coupons" swaps the
+ * page content for the partner's coupons iframe.
+ *
+ * PLACEHOLDER for now — the final design/spec for this switcher is still
+ * pending; expect markup and styles to be replaced when it lands.
+ */
+import { useTranslation } from 'react-i18next'
+import styles from './styles.mobile.module.css'
+
+export type PortalView = 'coupons' | 'cashback'
+
+interface Props {
+    value: PortalView
+    onChange: (view: PortalView) => void
+}
+
+const CouponsToggle = ({ value, onChange }: Props) => {
+    const { t } = useTranslation()
+    const options: { key: PortalView; label: string }[] = [
+        { key: 'coupons', label: t('coupons') },
+        { key: 'cashback', label: t('cashback') },
+    ]
+
+    return (
+        <div className={styles.root} role="tablist" aria-orientation="vertical">
+            {options.map(({ key, label }) => (
+                <button
+                    key={key}
+                    type="button"
+                    role="tab"
+                    aria-selected={value === key}
+                    className={`${styles.option} ${value === key ? styles.optionActive : ''}`}
+                    onClick={() => onChange(key)}
+                >
+                    {label}
+                </button>
+            ))}
+        </div>
+    )
+}
+
+export default CouponsToggle

--- a/src/components/CouponsToggle/styles.mobile.module.css
+++ b/src/components/CouponsToggle/styles.mobile.module.css
@@ -1,0 +1,48 @@
+/* Coupons / Cashback switcher. Visuals driven by CSS vars with neutral
+   fallbacks; selected option is a filled chip, the other is plain text.
+
+   PLACEHOLDER for now — the final design/spec for this switcher is still
+   pending; expect these styles to be replaced when it lands. */
+
+.root {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px;
+    align-self: flex-start;
+    box-sizing: border-box;
+    min-width: 90px;
+    border-radius: var(--coupons-toggle-radius, 8px);
+    background: var(--coupons-toggle-bg, #1E293B);
+}
+
+.option {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 10px;
+    height: 16px;
+    border: none;
+    border-radius: var(--coupons-toggle-active-radius, 8px);
+    background: transparent;
+    color: var(--coupons-toggle-f-c, #94A3B8);
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
+    font-size: var(--coupons-toggle-f-s, 12px);
+    font-weight: var(--coupons-toggle-f-w, 500);
+    line-height: var(--coupons-toggle-l-h, 16px);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.option:hover:not(.optionActive) {
+    color: var(--coupons-toggle-hover-f-c, var(--coupons-toggle-f-c, #94A3B8));
+    background: var(--coupons-toggle-hover-bg, rgba(245, 245, 245, 0.05));
+}
+
+.optionActive {
+    height: 30px;
+    background: var(--coupons-toggle-active-bg, #06B6D4);
+    color: var(--coupons-toggle-active-f-c, #F8FAFC);
+    cursor: default;
+}

--- a/src/components/FaqItem/styles.mobile.module.css
+++ b/src/components/FaqItem/styles.mobile.module.css
@@ -34,7 +34,7 @@
     cursor: pointer;
     text-align: left;
     color: inherit;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
 }
 
 .questionText {
@@ -88,7 +88,7 @@
 
 .answerLine {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--faq-answer-f-s, 12px);
     font-weight: var(--faq-answer-f-w, 400);
     line-height: var(--faq-answer-l-h, 16px);

--- a/src/components/FilterChip/styles.mobile.module.css
+++ b/src/components/FilterChip/styles.mobile.module.css
@@ -16,7 +16,7 @@
     border-radius: var(--filter-chip-radius, 4px);
     background: var(--filter-chip-bg, rgba(62, 72, 100, 0.50));
     color: var(--filter-chip-f-c, #F7F7F7);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--filter-chip-f-s, 14px);
     font-weight: 400;
     line-height: var(--filter-chip-l-h, 20px);

--- a/src/components/HistoryItem/styles.mobile.module.css
+++ b/src/components/HistoryItem/styles.mobile.module.css
@@ -34,7 +34,7 @@
     cursor: pointer;
     text-align: left;
     color: inherit;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     min-height: 40px;
 }
 
@@ -214,7 +214,7 @@
 
 .descriptionLine {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--history-description-f-s, 12px);
     font-weight: var(--history-description-f-w, 400);
     line-height: var(--history-description-l-h, 16px);

--- a/src/components/RetailerCard/styles.mobile.module.css
+++ b/src/components/RetailerCard/styles.mobile.module.css
@@ -13,7 +13,7 @@
     box-sizing: border-box;
     cursor: pointer;
     text-align: left;
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
     transition: background 0.15s ease;
 }
 

--- a/src/components/RetailerCardModal/styles.mobile.module.css
+++ b/src/components/RetailerCardModal/styles.mobile.module.css
@@ -33,7 +33,7 @@
     flex-direction: column;
     gap: 8px;
     overflow: hidden;
-    font-family: 'Prompt', sans-serif;
+    font-family: var(--font-family, 'Prompt', sans-serif);
 }
 
 /* ── Header (Cashback Details + X) ───────────────────────────────── */

--- a/src/components/Rewards/styles.mobile.module.css
+++ b/src/components/Rewards/styles.mobile.module.css
@@ -73,7 +73,7 @@
 
 .label {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--balance-label-f-s, 12px);
     font-weight: var(--balance-label-f-w, 400);
     line-height: var(--balance-label-l-h, 16px);
@@ -89,7 +89,7 @@
 }
 
 .amount {
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--balance-amount-f-s, 16px);
     font-weight: var(--balance-amount-f-w, 700);
     line-height: var(--balance-amount-l-h, 22px);
@@ -113,7 +113,7 @@
     border-radius: var(--balance-claim-btn-radius, 4px);
     background: var(--balance-claim-btn-bg, #6067F9);
     color: var(--balance-claim-btn-f-c, #F7F7F7);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--balance-claim-btn-f-s, 12px);
     font-weight: var(--balance-claim-btn-f-w, 400);
     line-height: 16px;
@@ -187,7 +187,7 @@
     border-radius: var(--helper-btn-radius, 4px);
     background: var(--helper-btn-bg, #2B344D);
     color: var(--helper-btn-f-c, #F7F7F7);
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--helper-btn-f-s, 12px);
     font-weight: var(--helper-btn-f-w, 400);
     line-height: 16px;

--- a/src/context/WalletAddressContext.tsx
+++ b/src/context/WalletAddressContext.tsx
@@ -8,10 +8,15 @@ interface WalletContextType {
     isTester: boolean
     walletAddress: string | null;
     setWalletAddress: (address: string) => void;
-    /** Wallet display name — from the JWT (verify) or dev URL params. */
+    /** Wallet display name - from the JWT (verify) or dev URL params. */
     walletName?: string;
-    /** Wallet emoji asset URL — from the JWT (verify) or dev URL params. */
+    /** Wallet emoji asset URL - from the JWT (verify) or dev URL params. */
     walletEmoji?: string;
+    /** Coupons iframe URL - refreshed wholesale on every SESSION_UPDATE
+     *  verify: absent in the new response means absent here (unlike
+     *  walletName/Emoji it does NOT keep the stale value, so the UI can
+     *  fall back to its connect placeholder). */
+    couponsIframeSrc?: string;
 }
 
 export const WalletContext = createContext<WalletContextType | undefined>(undefined);
@@ -22,6 +27,7 @@ export function WalletProvider({
     initIsTester,
     initialWalletName,
     initialWalletEmoji,
+    initialCouponsIframeSrc,
     mode = 'desktop',
 }: {
     children: ReactNode,
@@ -29,7 +35,8 @@ export function WalletProvider({
     initIsTester: boolean,
     initialWalletName?: string,
     initialWalletEmoji?: string,
-    // Current portal mode — preserved when a SESSION_UPDATE re-themes, so the
+    initialCouponsIframeSrc?: string,
+    // Current portal mode - preserved when a SESSION_UPDATE re-themes, so the
     // mobile stylesheet tags aren't stripped by a default 'desktop' call.
     mode?: StylesheetMode,
 }) {
@@ -40,6 +47,7 @@ export function WalletProvider({
     // wallet switch updates the name/emoji without a full reload.
     const [walletName, setWalletName] = useState<string | undefined>(initialWalletName)
     const [walletEmoji, setWalletEmoji] = useState<string | undefined>(initialWalletEmoji)
+    const [couponsIframeSrc, setCouponsIframeSrc] = useState<string | undefined>(initialCouponsIframeSrc)
 
     useEffect(() => {
         const handleMessage = async (event: MessageEvent) => {
@@ -56,10 +64,13 @@ export function WalletProvider({
                     setWalletAddress(res.info.walletAddress || null)
                     setIsTester(!!res.info.isTester && ENV !== 'prod')
                     // Only overwrite when the new token actually carries the
-                    // field — otherwise keep the value seeded from the loader
+                    // field - otherwise keep the value seeded from the loader
                     // (e.g. dev URL params the JWT doesn't echo).
                     if (res.info.walletName) setWalletName(res.info.walletName)
                     if (res.info.walletEmoji) setWalletEmoji(res.info.walletEmoji)
+                    // Replace, don't merge: a verify without couponsIframeSrc
+                    // (e.g. wallet disconnected) must clear the stale URL.
+                    setCouponsIframeSrc(res.info.couponsIframeSrc || undefined)
                     if (res.info.theme) {
                         loadStylesheet(res.info.theme.toLowerCase(), res.info.platform || 'DEFAULT', mode)
                     }
@@ -78,7 +89,7 @@ export function WalletProvider({
     }, [mode])
 
     return (
-        <WalletContext.Provider value={{ isTester, walletAddress, setWalletAddress, walletName, walletEmoji }}>
+        <WalletContext.Provider value={{ isTester, walletAddress, setWalletAddress, walletName, walletEmoji, couponsIframeSrc }}>
             {children}
         </WalletContext.Provider>
     );

--- a/src/context/WalletAddressContext.tsx
+++ b/src/context/WalletAddressContext.tsx
@@ -51,6 +51,15 @@ export function WalletProvider({
 
     useEffect(() => {
         const handleMessage = async (event: MessageEvent) => {
+            // Only the embedding host page may drive the session. When the
+            // portal is embedded, the host is `window.parent`; anything else -
+            // the nested coupons iframe (its messages arrive with `source` set
+            // to that iframe's window), wallet-extension content scripts
+            // posting to this window (`source === window`), or any other
+            // frame — must not be able to swap the session or re-theme the
+            // portal. When the portal runs top-level, `window.parent` is the
+            // window itself, so dev/console posts still work.
+            if (event.source !== window.parent) return
             const data = event.data
             // Validate message shape before trusting the payload.
             if (!data || typeof data !== 'object') return

--- a/src/context/WalletAddressContext.tsx
+++ b/src/context/WalletAddressContext.tsx
@@ -7,7 +7,7 @@ import type { StylesheetMode } from '../utils/loadStylesheet';
 interface WalletContextType {
     isTester: boolean
     walletAddress: string | null;
-    setWalletAddress: (address: string) => void;
+    setWalletAddress: (address: string | null) => void;
     /** Wallet display name - from the JWT (verify) or dev URL params. */
     walletName?: string;
     /** Wallet emoji asset URL - from the JWT (verify) or dev URL params. */
@@ -20,6 +20,20 @@ interface WalletContextType {
 }
 
 export const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+// Only https may reach the coupons <iframe src> - an iframe src is an
+// injection sink (a javascript: URL would run in the portal's origin), so
+// allowlist the scheme even though the value arrives via the verified JWT.
+// Parsed with the URL API so the check matches how the browser will actually
+// interpret the string (anything not parseable as an absolute URL is dropped).
+const safeIframeSrc = (src?: string): string | undefined => {
+    if (!src) return undefined
+    try {
+        return new URL(src).protocol === 'https:' ? src : undefined
+    } catch {
+        return undefined
+    }
+}
 
 export function WalletProvider({
     children,
@@ -47,7 +61,7 @@ export function WalletProvider({
     // wallet switch updates the name/emoji without a full reload.
     const [walletName, setWalletName] = useState<string | undefined>(initialWalletName)
     const [walletEmoji, setWalletEmoji] = useState<string | undefined>(initialWalletEmoji)
-    const [couponsIframeSrc, setCouponsIframeSrc] = useState<string | undefined>(initialCouponsIframeSrc)
+    const [couponsIframeSrc, setCouponsIframeSrc] = useState<string | undefined>(() => safeIframeSrc(initialCouponsIframeSrc))
 
     useEffect(() => {
         const handleMessage = async (event: MessageEvent) => {
@@ -79,7 +93,7 @@ export function WalletProvider({
                     if (res.info.walletEmoji) setWalletEmoji(res.info.walletEmoji)
                     // Replace, don't merge: a verify without couponsIframeSrc
                     // (e.g. wallet disconnected) must clear the stale URL.
-                    setCouponsIframeSrc(res.info.couponsIframeSrc || undefined)
+                    setCouponsIframeSrc(safeIframeSrc(res.info.couponsIframeSrc))
                     if (res.info.theme) {
                         loadStylesheet(res.info.theme.toLowerCase(), res.info.platform || 'DEFAULT', mode)
                     }

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -30,6 +30,7 @@ const Layout = () => {
             initIsTester={data.isTester}
             initialWalletName={data.walletName}
             initialWalletEmoji={data.walletEmoji}
+            initialCouponsIframeSrc={data.couponsIframeSrc}
             mode={data.useMobilePortal ? 'mobile' : 'desktop'}
         >
             <AnalyticsProvider

--- a/src/pages/FrequentlyAskedQuestion/styles.mobile.module.css
+++ b/src/pages/FrequentlyAskedQuestion/styles.mobile.module.css
@@ -80,7 +80,7 @@
 
 .intro {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--faq-intro-f-s, 14px);
     font-weight: var(--faq-intro-f-w, 400);
     line-height: var(--faq-intro-l-h, 20px);

--- a/src/pages/History/styles.mobile.module.css
+++ b/src/pages/History/styles.mobile.module.css
@@ -95,7 +95,7 @@
 .intro {
     margin: 0;
     padding: 0 16px;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--history-intro-f-s, 12px);
     font-weight: var(--history-intro-f-w, 400);
     line-height: var(--history-intro-l-h, 16px);
@@ -175,7 +175,7 @@
 
 .emptyText {
     margin: 0;
-    font-family: 'Prompt', system-ui, sans-serif;
+    font-family: var(--font-family, 'Prompt', system-ui, sans-serif);
     font-size: var(--history-empty-f-s, 14px);
     font-weight: var(--history-empty-f-w, 400);
     line-height: var(--history-empty-l-h, 20px);

--- a/src/pages/Home/Home.mobile.tsx
+++ b/src/pages/Home/Home.mobile.tsx
@@ -1,15 +1,29 @@
 /** Mobile portal home page: hero + filter row (categories / search / chip) +
  * retailer list + claim modal. Pure UI — logic in useHomePage. */
+import { useState } from 'react'
+import { useRouteLoaderData } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import MobileHeroSection from '../../components/HeroSection/HeroSection.mobile'
 import MobileCategories from '../../components/Categories/Categories.mobile'
 import MobileSearchBar from '../../components/Search/Search.mobile'
 import MobileFilterChip from '../../components/FilterChip/FilterChip.mobile'
 import MobileCardsList from '../../components/CardsList/CardsList.mobile'
 import MobileClaimModal from '../../components/ClaimModal/ClaimModal.mobile'
+import MobileCouponsToggle, { PortalView } from '../../components/CouponsToggle/CouponsToggle.mobile'
+import MobileCouponsConnect from '../../components/CouponsConnect/CouponsConnect.mobile'
 import { useHomePage } from './useHomePage'
 import styles from './styles.mobile.module.css'
 
 const MobileHome = () => {
+    // Coupons/Cashback switcher - the feature is enabled when verify returned
+    // couponsIframeSrc (initially via the loader, or later via SESSION_UPDATE;
+    // mobile-only by construction: this page renders only on mobile). The live
+    // src comes from the wallet context so each new verify replaces it; the
+    // iframe mounts only with a connected wallet AND a current src - otherwise
+    // the Coupons view shows a connect placeholder.
+    const { couponsIframeSrc: initialCouponsIframeSrc } = useRouteLoaderData('root') as LoaderData
+    const { t } = useTranslation()
+    const [view, setView] = useState<PortalView>('cashback')
     const {
         category,
         setCategory,
@@ -45,7 +59,11 @@ const MobileHome = () => {
         handleOpenClaim,
         handleCloseClaim,
         handleConfirmClaim,
+        couponsIframeSrc,
     } = useHomePage()
+
+    const couponsEnabled = Boolean(initialCouponsIframeSrc || couponsIframeSrc)
+    const showCoupons = couponsEnabled && view === 'coupons'
 
     // Decide what occupies the tabs-row slot. Priority: open input >
     // committed search chip > category chip > full categories row.
@@ -83,17 +101,34 @@ const MobileHome = () => {
     return (
         <div className={styles.root} data-testid="mobile-home">
             <main className={styles.content}>
-                <MobileHeroSection onClaim={handleOpenClaim} />
-                {renderFilterRow()}
-                <MobileCardsList
-                    retailers={retailers}
-                    metadata={metadata}
-                    isLoading={isLoadingRetailers}
-                    isFetchingNextPage={isFetchingNextPage}
-                    hasNextPage={Boolean(hasNextPage)}
-                    onFetchNextPage={fetchNextPage}
-                    isSearching={isSearching}
-                />
+                {couponsEnabled && (
+                    <MobileCouponsToggle value={view} onChange={setView} />
+                )}
+                {showCoupons ? (
+                    walletAddress && couponsIframeSrc ? (
+                        <iframe
+                            className={styles.couponsFrame}
+                            src={couponsIframeSrc}
+                            title={t('coupons')}
+                        />
+                    ) : (
+                        <MobileCouponsConnect />
+                    )
+                ) : (
+                    <>
+                        <MobileHeroSection onClaim={handleOpenClaim} />
+                        {renderFilterRow()}
+                        <MobileCardsList
+                            retailers={retailers}
+                            metadata={metadata}
+                            isLoading={isLoadingRetailers}
+                            isFetchingNextPage={isFetchingNextPage}
+                            hasNextPage={Boolean(hasNextPage)}
+                            onFetchNextPage={fetchNextPage}
+                            isSearching={isSearching}
+                        />
+                    </>
+                )}
             </main>
             <MobileClaimModal
                 state={claimState}

--- a/src/pages/Home/styles.mobile.module.css
+++ b/src/pages/Home/styles.mobile.module.css
@@ -26,3 +26,15 @@
 .content > *:not(:last-child) {
     flex-shrink: 0;
 }
+
+/* Coupons view — the partner iframe fills the space below the switcher,
+   full-bleed: cancel the content gutter so the coupons page runs
+   edge-to-edge and down to the bottom (Figma 278:4832). */
+.couponsFrame {
+    flex: 1 1 auto;
+    min-height: 0;
+    margin: 0 -16px -16px;
+    border: 0;
+    display: block;
+    background: var(--bg);
+}

--- a/src/pages/Home/useHomePage.ts
+++ b/src/pages/Home/useHomePage.ts
@@ -23,7 +23,7 @@ const SEARCH_MIN_CHARS = 2
 
 export const useHomePage = () => {
     const { platform, userId, flowId, cryptoSymbols } = useRouteLoaderData('root') as LoaderData
-    const { walletAddress, walletName, walletEmoji } = useWalletAddress()
+    const { walletAddress, walletName, walletEmoji, couponsIframeSrc } = useWalletAddress()
     const queryClient = useQueryClient()
 
     const [category, setCategory] = useState<CategoriesItem | null>(null)
@@ -241,5 +241,7 @@ export const useHomePage = () => {
         handleOpenClaim,
         handleCloseClaim,
         handleConfirmClaim,
+        // coupons - live value from the wallet context (refreshed per verify)
+        couponsIframeSrc,
     }
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -89,6 +89,7 @@ const rootLoader = async () => {
             walletEmoji: params.get('walletEmoji') || undefined,
             bringTou: params.get('bringTou') || undefined,
             privacy: params.get('privacy') || undefined,
+            couponsIframeSrc: params.get('couponsIframeSrc') || undefined,
         }
         if (!dev.platform) throw Error('Missing platform')
         const devPlatform = dev.platform.toUpperCase()

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -50,6 +50,10 @@ interface LoaderData {
     walletEmoji?: string
     walletName?: string
     useMobilePortal?: boolean
+    // Coupons iframe URL from verify. When present (mobile only) the portal
+    // shows a Coupons/Cashback switcher and embeds this src on Coupons;
+    // desktop ignores it and stays cashback-only.
+    couponsIframeSrc?: string
     variant: string
     bringTou?: string
     privacy?: string


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/365
_____
Stacked on `solflareMobileTheme`  - retarget to `main` after the theme PR merges.

## Feature
- `couponsIframeSrc` plumbed from the verify response through loader/context into
  the mobile home
- Coupons/Cashback switcher shown when the platform has coupons; the Coupons view
  swaps the page content for the partner's iframe
- Connect placeholder (`CouponsConnect`) prompting wallet connect when no wallet is
  attached
- Solflare dark-theme vars for the new coupons UI

## Hardening & a11y
- `WalletAddressContext` now accepts `SESSION_UPDATE` only from `window.parent` —
  embedding a third-party coupons iframe otherwise lets any nested frame spoof
  session/theme updates (swap the session to another wallet, trigger arbitrary
  stylesheet loads)
- `CouponsToggle`: incomplete ARIA tabs pattern replaced with plain toggle buttons
  using `aria-pressed`
