### PR TITLE
feat(dev-wrapper): portal backdrop colour/image, west resize handles

### DIFF
--- a/dev-wrapper/README.md
+++ b/dev-wrapper/README.md
@@ -95,9 +95,20 @@ Open <http://localhost:5174>.
 
 - **Header — view toolbar** — centred display controls: view mode
   (Desktop / Mobile / Responsive), device preset + rotate, stage width×height,
-  and the wrapper-background swatch / hatch / reset. Controls that don't apply
-  to the current mode stay visible but grayed out (e.g. everything but the
-  mode select in Desktop, where the iframe covers the whole frame).
+  and the backdrop controls. Controls that don't apply to the current mode
+  stay visible but grayed out (e.g. the device and size controls in Desktop,
+  where the iframe covers the whole frame). The colour swatch and 🖼 image
+  choose what shows *under the portal* (visible wherever the portal page is
+  transparent), while the wrapper surround around the stage keeps a fixed
+  grey hatch; the ▣/⛶ button extends the colour/image from the stage to the
+  full wrapper. 🖼 gestures: click to pick a file — or toggle a loaded image
+  off/on (the colour shows while it's off) — Shift+click to paste from the
+  clipboard (image data or a copied image URL), Alt+click to enter a URL,
+  Ctrl+click to clear. Committing a colour also switches the image off.
+  Everything persists across reloads (the image in IndexedDB — too big for
+  localStorage; colour, off/on and area choice in localStorage), and ↺
+  removes colour + image together. (Page-wide Ctrl+V belongs to the
+  visual-diff overlay, so background paste lives on the button.)
 - **Header / wallet button** — top-right. Click to connect (sends
   `SESSION_UPDATE`) or, when connected, click the short `0xab12…cdef`
   pill to disconnect.

--- a/dev-wrapper/README.md
+++ b/dev-wrapper/README.md
@@ -96,11 +96,11 @@ Open <http://localhost:5174>.
 - **Header — view toolbar** — centred display controls: view mode
   (Desktop / Mobile / Responsive), device preset + rotate, stage width×height,
   and the backdrop controls. Controls that don't apply to the current mode
-  stay visible but grayed out (e.g. the device and size controls in Desktop,
-  where the iframe covers the whole frame). The colour swatch and 🖼 image
+  stay visible but grayed out (e.g. the device, size and backdrop-area
+  controls in Desktop, where the iframe covers the whole frame). The color swatch and 🖼 image
   choose what shows *under the portal* (visible wherever the portal page is
   transparent), while the wrapper surround around the stage keeps a fixed
-  grey hatch; the ▣/⛶ button extends the colour/image from the stage to the
+  grey hatch; the ▣/⛶ button extends the color/image from the stage to the
   full wrapper. 🖼 gestures: click to pick a file — or toggle a loaded image
   off/on (the colour shows while it's off) — Shift+click to paste from the
   clipboard (image data or a copied image URL), Alt+click to enter a URL,

--- a/dev-wrapper/index.html
+++ b/dev-wrapper/index.html
@@ -33,9 +33,11 @@
                     <input id="responsiveHeight" type="number" min="200" max="2400" step="1" title="Stage height (px, Responsive mode)" aria-label="Stage height in pixels" />
                 </div>
                 <div class="tb-group" id="pageBgRow">
-                    <input id="pageBgColor" type="color" title="Colour of the wrapper area around the portal stage (Mobile/Responsive modes — in Desktop the portal fills the frame)" aria-label="Wrapper background colour" />
-                    <button id="pageBgHatch" type="button" title="Toggle diagonal hatching on the area around the stage" aria-label="Toggle background hatching">&#9640;</button>
-                    <button id="pageBgReset" type="button" title="Reset to the default colour with hatching" aria-label="Reset wrapper background">&#8634;</button>
+                    <input id="pageBgColor" type="color" title="Backdrop colour under the portal (shows wherever the portal page is transparent). Committing a colour switches a loaded image off." aria-label="Backdrop colour" />
+                    <button id="pageBgImage" type="button" title="Backdrop image under the portal (e.g. a partner-site screenshot). Click: pick a file, or toggle a loaded image off/on · Shift+click: paste from clipboard (image or copied URL) · Alt+click: enter a URL · Ctrl+click: clear." aria-label="Backdrop image">&#128444;&#xFE0E;</button>
+                    <button id="pageBgImageScope" type="button" title="Backdrop area: portal stage only &#8646; full wrapper" aria-label="Toggle backdrop area">&#9635;&#xFE0E;</button>
+                    <button id="pageBgReset" type="button" title="Remove backdrop colour and image (the wrapper surround keeps its default grey hatch)" aria-label="Reset backdrop">&#8634;</button>
+                    <input id="pageBgImageFile" type="file" accept="image/*" hidden />
                 </div>
             </div>
             <div class="bar-actions">
@@ -178,8 +180,10 @@
                 <div class="frame-stage" id="frameStage">
                     <iframe id="portal" title="Bring Cashback Portal"></iframe>
                     <div class="resize-handle handle-e" id="resizeE" title="Drag to resize"></div>
+                    <div class="resize-handle handle-w" id="resizeW" title="Drag to resize"></div>
                     <div class="resize-handle handle-s" id="resizeS" title="Drag to resize"></div>
                     <div class="resize-handle handle-se" id="resizeSE" title="Drag to resize"></div>
+                    <div class="resize-handle handle-sw" id="resizeSW" title="Drag to resize"></div>
                 </div>
             </section>
         </main>

--- a/dev-wrapper/main.ts
+++ b/dev-wrapper/main.ts
@@ -271,78 +271,220 @@ rotateBtn.addEventListener('click', () => {
     void refresh()
 })
 
-// Stage background: colour + hatch of the #frame surround around the portal
-// stage. Grayed out in Desktop mode — the iframe covers the frame edge-to-
-// edge there, so there's nothing to colour. Nothing stored = default
-// colour WITH hatching; the ↺ button returns to that default. (Same storage
-// key as when this control lived in the visual-diff panel, so an already-
-// picked colour carries over.)
+// Portal backdrop: what shows under the portal iframe, visible wherever the
+// portal page is transparent — a flat colour or an image (both persisted);
+// the image wins while loaded and switched on. The wrapper
+// surround around the stage keeps a fixed grey+hatch (see .frame in
+// style.css); the ▣/⛶ scope button extends the colour/image from the stage
+// to the full wrapper instead. ↺ removes colour and image together.
+// (PAGE_BG_KEY predates this control — same storage key as when it lived in
+// the visual-diff panel, so an already-picked colour carries over.)
 const PAGE_BG_KEY = 'bring.visualDiff.pageBg'
 const PAGE_BG_DEFAULT = '#0f0f1a'
 const pageBgColorEl = $<HTMLInputElement>('pageBgColor')
-const pageBgHatchBtn = $<HTMLButtonElement>('pageBgHatch')
 const pageBgResetBtn = $<HTMLButtonElement>('pageBgReset')
+const pageBgImageBtn = $<HTMLButtonElement>('pageBgImage')
+const pageBgImageScopeBtn = $<HTMLButtonElement>('pageBgImageScope')
+const pageBgImageFileEl = $<HTMLInputElement>('pageBgImageFile')
+// Declared here (not at the drag-resize code) because applyPageBg paints the
+// stage-scoped backdrop image onto it at module init.
+const frameStageEl = $<HTMLDivElement>('frameStage')
 
-type PageBg = { color: string; hatch: boolean }
-let pageBg: PageBg | null = (() => {
+// Backdrop image (e.g. a partner-site screenshot behind a transparent
+// portal). Click = file picker when none is loaded, or toggle the loaded
+// image off/on (the colour shows while off); Shift+click = paste from the
+// clipboard (image data or a copied URL); Alt+click = type/paste a URL;
+// Ctrl+click = clear/forget the image. Paste is scoped to the button — a
+// page-wide Ctrl+V is already claimed by the visual-diff overlay. The image
+// persists across reloads in IndexedDB — localStorage can't hold a
+// screenshot-sized blob. Remote URLs are stored as plain strings; the
+// off/on and scope choices persist in localStorage.
+const PAGE_BG_SCOPE_KEY = 'bring-dev-wrapper:page-bg-scope'
+const PAGE_BG_IMAGE_ON_KEY = 'bring-dev-wrapper:page-bg-image-on'
+let pageBgScope: 'frame' | 'stage' =
+    localStorage.getItem(PAGE_BG_SCOPE_KEY) === 'frame' ? 'frame' : 'stage'
+let pageBgImageUrl: string | null = null
+let pageBgImageOn = localStorage.getItem(PAGE_BG_IMAGE_ON_KEY) !== '0'
+const saveImageOn = () => localStorage.setItem(PAGE_BG_IMAGE_ON_KEY, pageBgImageOn ? '1' : '0')
+
+// Tiny key-value IndexedDB store for the image. All operations are
+// best-effort: if IDB is unavailable the image simply doesn't survive a
+// reload, everything else keeps working.
+const openBgDb = () => new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('bring-dev-wrapper', 1)
+    req.onupgradeneeded = () => req.result.createObjectStore('pageBgImage')
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+})
+const idbDone = <T>(req: IDBRequest<T>) => new Promise<T>((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+})
+const bgImageStore = async (mode: IDBTransactionMode) =>
+    (await openBgDb()).transaction('pageBgImage', mode).objectStore('pageBgImage')
+const persistBgImage = async (value: Blob | string) => {
+    try { await idbDone((await bgImageStore('readwrite')).put(value, 'image')) } catch { /* best-effort */ }
+}
+const deletePersistedBgImage = async () => {
+    try { await idbDone((await bgImageStore('readwrite')).delete('image')) } catch { /* best-effort */ }
+}
+const restoreBgImage = async () => {
     try {
-        const parsed = JSON.parse(localStorage.getItem(PAGE_BG_KEY) || '') as Partial<PageBg>
-        if (typeof parsed.color === 'string') return { color: parsed.color, hatch: !!parsed.hatch }
+        const stored = await idbDone<Blob | string | undefined>((await bgImageStore('readonly')).get('image'))
+        if (!stored) return
+        pageBgImageUrl = typeof stored === 'string' ? stored : URL.createObjectURL(stored)
+        applyPageBg()
+    } catch { /* best-effort */ }
+}
+
+// Drop the in-memory image (revoking a blob's object URL; remote URLs from
+// the Shift/Alt+click paths have nothing to revoke).
+const revokeBgImageUrl = () => {
+    if (!pageBgImageUrl) return
+    if (pageBgImageUrl.startsWith('blob:')) URL.revokeObjectURL(pageBgImageUrl)
+    pageBgImageUrl = null
+}
+// User-facing clear (Ctrl+click / ↺): forget the image everywhere.
+const clearPageBgImage = () => {
+    revokeBgImageUrl()
+    void deletePersistedBgImage()
+}
+// `source` is what gets persisted: the image Blob itself, or the remote URL.
+const setPageBgImage = (url: string, source: Blob | string) => {
+    revokeBgImageUrl()
+    pageBgImageUrl = url
+    pageBgImageOn = true
+    saveImageOn()
+    void persistBgImage(source)
+    applyPageBg()
+}
+// Async Clipboard API (needs clipboard-read permission): prefer image data,
+// fall back to a copied http(s) URL used directly as the background source.
+const pasteBgFromClipboard = async () => {
+    if (!navigator.clipboard?.read) {
+        setStatus('Clipboard API unavailable — use Alt+click to enter a URL', true)
+        return
+    }
+    try {
+        for (const item of await navigator.clipboard.read()) {
+            const type = item.types.find(t => t.startsWith('image/'))
+            if (!type) continue
+            const blob = await item.getType(type)
+            setPageBgImage(URL.createObjectURL(blob), blob)
+            setStatus('Backdrop image pasted from clipboard')
+            return
+        }
+        const text = (await navigator.clipboard.readText().catch(() => '')).trim()
+        if (/^https?:\/\//.test(text)) {
+            setPageBgImage(text, text)
+            setStatus('Backdrop image set from copied URL')
+            return
+        }
+        setStatus('Clipboard has no image or URL', true)
+    } catch (err) {
+        setStatus(`Paste failed: ${err instanceof Error ? err.message : String(err)}`, true)
+    }
+}
+
+let pageBgColor: string | null = (() => {
+    try {
+        const parsed = JSON.parse(localStorage.getItem(PAGE_BG_KEY) || '') as { color?: string }
+        if (typeof parsed.color === 'string' && /^#[0-9a-fA-F]{6}$/.test(parsed.color)) return parsed.color
     } catch { /* nothing stored / corrupt — use the default */ }
     return null
 })()
-const savePageBg = () => {
-    if (pageBg) localStorage.setItem(PAGE_BG_KEY, JSON.stringify(pageBg))
+const savePageBgColor = () => {
+    if (pageBgColor) localStorage.setItem(PAGE_BG_KEY, JSON.stringify({ color: pageBgColor }))
     else localStorage.removeItem(PAGE_BG_KEY)
 }
 // `live` paints a not-yet-committed picker value while the colour wheel is
-// open. Inline styles override the `.frame.*` stylesheet backgrounds. The
-// hatch stripe tint flips with the colour's luminance so the texture stays
-// visible on both dark and light picks.
+// open. The fill goes on the scoped target as an inline style (overriding
+// the stylesheet grey+hatch when the scope is the full wrapper); the other
+// element keeps its stylesheet look.
 const applyPageBg = (live?: string) => {
-    const active = live !== undefined
-        ? { color: live, hatch: pageBg?.hatch ?? true }
-        : pageBg ?? { color: PAGE_BG_DEFAULT, hatch: true }
-    pageBgColorEl.value = active.color
-    pageBgHatchBtn.classList.toggle('active', active.hatch)
-    const hex = /^#[0-9a-fA-F]{6}$/.test(active.color) ? active.color : PAGE_BG_DEFAULT
-    const [r, g, b] = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16))
-    const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
-    const stripe = luminance > 0.55 ? 'rgba(0,0,0,0.07)' : 'rgba(255,255,255,0.05)'
-    frameEl.style.background = hex
-    frameEl.style.backgroundImage = active.hatch
-        ? `repeating-linear-gradient(45deg, ${stripe} 0 8px, transparent 8px 16px)`
-        : 'none'
+    const imageShown = Boolean(pageBgImageUrl) && pageBgImageOn
+    pageBgColorEl.value = live ?? pageBgColor ?? PAGE_BG_DEFAULT
+    pageBgImageBtn.classList.toggle('active', imageShown)
+    pageBgImageScopeBtn.textContent = pageBgScope === 'stage' ? '▣' : '⛶'
+    pageBgImageScopeBtn.title = pageBgScope === 'stage'
+        ? 'Backdrop colour/image covers the portal stage only — click for full wrapper'
+        : 'Backdrop colour/image covers the full wrapper — click for portal stage only'
+    frameEl.style.background = ''
+    frameStageEl.style.background = ''
+    // While the colour picker is open, preview the colour even over an image.
+    const fill = live
+        ?? (imageShown ? `url("${pageBgImageUrl}") top center / cover no-repeat` : pageBgColor)
+    if (!fill) return
+    const target = pageBgScope === 'frame' ? frameEl : frameStageEl
+    target.style.background = fill
 }
 // Repaint live while the picker is open; persist only on commit, so dragging
 // through the colour wheel doesn't write on every frame.
 pageBgColorEl.addEventListener('input', () => applyPageBg(pageBgColorEl.value))
 pageBgColorEl.addEventListener('change', () => {
-    pageBg = { color: pageBgColorEl.value, hatch: pageBg?.hatch ?? true }
-    savePageBg()
+    // Committing a colour is an explicit "show the colour": switch a loaded
+    // image off (it stays loaded — click 🖼 to bring it back).
+    pageBgImageOn = false
+    saveImageOn()
+    pageBgColor = pageBgColorEl.value
+    savePageBgColor()
     applyPageBg()
 })
-pageBgHatchBtn.addEventListener('click', () => {
-    pageBg = { color: pageBgColorEl.value, hatch: !(pageBg?.hatch ?? true) }
-    savePageBg()
-    applyPageBg()
-})
+// Dismissing the colour picker without picking: repaint the current state
+// (restores an image the live preview painted over).
+pageBgColorEl.addEventListener('cancel', () => applyPageBg())
 pageBgResetBtn.addEventListener('click', () => {
-    pageBg = null
-    savePageBg()
+    clearPageBgImage()
+    pageBgColor = null
+    savePageBgColor()
     applyPageBg()
+})
+pageBgImageBtn.addEventListener('click', (e) => {
+    if (e.ctrlKey) {
+        clearPageBgImage()
+        applyPageBg()
+        return
+    }
+    if (e.shiftKey) {
+        void pasteBgFromClipboard()
+        return
+    }
+    if (e.altKey) {
+        const url = prompt('Backdrop image URL:')?.trim()
+        if (url) setPageBgImage(url, url)
+        return
+    }
+    // A loaded image toggles off/on (colour shows while off); with none
+    // loaded, plain click opens the file picker.
+    if (pageBgImageUrl) {
+        pageBgImageOn = !pageBgImageOn
+        saveImageOn()
+        applyPageBg()
+        return
+    }
+    pageBgImageFileEl.click()
+})
+pageBgImageScopeBtn.addEventListener('click', () => {
+    pageBgScope = pageBgScope === 'stage' ? 'frame' : 'stage'
+    localStorage.setItem(PAGE_BG_SCOPE_KEY, pageBgScope)
+    applyPageBg()
+})
+pageBgImageFileEl.addEventListener('change', () => {
+    const file = pageBgImageFileEl.files?.[0]
+    if (!file) return
+    setPageBgImage(URL.createObjectURL(file), file)
+    // Reset the input so picking the same file again still fires `change`.
+    pageBgImageFileEl.value = ''
 })
 applyPageBg()
+// Async: repaints with the persisted image once (if) it loads from IndexedDB.
+void restoreBgImage()
 
 const applyViewMode = (mode: string) => {
     frameEl.classList.toggle('mobile', mode === 'mobile')
     frameEl.classList.toggle('responsive', mode === 'responsive')
-    const framed = mode === 'mobile' || mode === 'responsive'
     responsiveWidthEl.disabled = mode !== 'responsive'
     responsiveHeightEl.disabled = mode !== 'responsive'
-    pageBgColorEl.disabled = !framed
-    pageBgHatchBtn.disabled = !framed
-    pageBgResetBtn.disabled = !framed
     applyDevice(mode)
 }
 const savedViewMode = localStorage.getItem(VIEW_MODE_KEY)
@@ -386,14 +528,14 @@ for (const el of [responsiveWidthEl, responsiveHeightEl]) {
     el.addEventListener('change', onSizeCommit)
 }
 
-// Drag-resize: east/south edges and the SE corner of the responsive stage.
+// Drag-resize: east/west/south edges and the SE/SW corners of the responsive
+// stage.
 // Sizes are computed from the cursor position against the stage rect (not
 // deltas) so the dragged edge tracks the cursor even though the stage is
 // centered and shifts as it grows.
-const frameStageEl = $<HTMLDivElement>('frameStage')
 const clampNum = (value: number, el: HTMLInputElement) =>
     Math.min(Number(el.max), Math.max(Number(el.min), Math.round(value)))
-const setupResizeHandle = (id: string, axes: { x?: boolean; y?: boolean }) => {
+const setupResizeHandle = (id: string, axes: { x?: 'e' | 'w'; y?: boolean }) => {
     const handle = $<HTMLDivElement>(id)
     handle.addEventListener('pointerdown', (e) => {
         e.preventDefault()
@@ -403,7 +545,10 @@ const setupResizeHandle = (id: string, axes: { x?: boolean; y?: boolean }) => {
         const startH = savedSize.h
         const onMove = (ev: PointerEvent) => {
             const rect = frameStageEl.getBoundingClientRect()
-            if (axes.x) savedSize.w = clampNum(ev.clientX - rect.left, responsiveWidthEl)
+            // The stage is centered, so a west drag mirrors the east math:
+            // width is measured from the cursor to the opposite edge.
+            if (axes.x === 'e') savedSize.w = clampNum(ev.clientX - rect.left, responsiveWidthEl)
+            if (axes.x === 'w') savedSize.w = clampNum(rect.right - ev.clientX, responsiveWidthEl)
             if (axes.y) savedSize.h = clampNum(ev.clientY - rect.top, responsiveHeightEl)
             applyResponsiveSize()
             responsiveWidthEl.value = String(savedSize.w)
@@ -423,9 +568,11 @@ const setupResizeHandle = (id: string, axes: { x?: boolean; y?: boolean }) => {
         handle.addEventListener('pointercancel', onUp, { once: true })
     })
 }
-setupResizeHandle('resizeE', { x: true })
+setupResizeHandle('resizeE', { x: 'e' })
+setupResizeHandle('resizeW', { x: 'w' })
 setupResizeHandle('resizeS', { y: true })
-setupResizeHandle('resizeSE', { x: true, y: true })
+setupResizeHandle('resizeSE', { x: 'e', y: true })
+setupResizeHandle('resizeSW', { x: 'w', y: true })
 
 const STYLE_AS_KEY = 'bring-dev-wrapper:style-as'
 styleAsEl.value = localStorage.getItem(STYLE_AS_KEY) || ''

--- a/dev-wrapper/main.ts
+++ b/dev-wrapper/main.ts
@@ -310,7 +310,10 @@ const saveImageOn = () => localStorage.setItem(PAGE_BG_IMAGE_ON_KEY, pageBgImage
 // Tiny key-value IndexedDB store for the image. All operations are
 // best-effort: if IDB is unavailable the image simply doesn't survive a
 // reload, everything else keeps working.
-const openBgDb = () => new Promise<IDBDatabase>((resolve, reject) => {
+// One lazily-opened connection, reused for every operation - a fresh open()
+// per call would pile up connections that are never closed.
+let bgDbPromise: Promise<IDBDatabase> | null = null
+const openBgDb = () => bgDbPromise ??= new Promise<IDBDatabase>((resolve, reject) => {
     const req = indexedDB.open('bring-dev-wrapper', 1)
     req.onupgradeneeded = () => req.result.createObjectStore('pageBgImage')
     req.onsuccess = () => resolve(req.result)
@@ -412,8 +415,10 @@ const applyPageBg = (live?: string) => {
     frameEl.style.background = ''
     frameStageEl.style.background = ''
     // While the colour picker is open, preview the colour even over an image.
+    // JSON.stringify escapes quotes/backslashes an Alt+click-typed URL could
+    // contain, which would otherwise invalidate the whole declaration.
     const fill = live
-        ?? (imageShown ? `url("${pageBgImageUrl}") top center / cover no-repeat` : pageBgColor)
+        ?? (imageShown ? `url(${JSON.stringify(pageBgImageUrl)}) top center / cover no-repeat` : pageBgColor)
     if (!fill) return
     const target = pageBgScope === 'frame' ? frameEl : frameStageEl
     target.style.background = fill
@@ -485,6 +490,9 @@ const applyViewMode = (mode: string) => {
     frameEl.classList.toggle('responsive', mode === 'responsive')
     responsiveWidthEl.disabled = mode !== 'responsive'
     responsiveHeightEl.disabled = mode !== 'responsive'
+    // In Desktop the stage covers the whole frame, so the stage-vs-full-
+    // wrapper backdrop scope makes no visible difference — gray it out.
+    pageBgImageScopeBtn.disabled = mode !== 'mobile' && mode !== 'responsive'
     applyDevice(mode)
 }
 const savedViewMode = localStorage.getItem(VIEW_MODE_KEY)

--- a/dev-wrapper/style.css
+++ b/dev-wrapper/style.css
@@ -604,8 +604,12 @@ html, body {
 
 .status.error { color: #ff7196; }
 
+/* The wrapper surround is a fixed grey + hatch, defined here only. The
+   toolbar's colour/image controls paint inline styles over the stage (or, in
+   full-wrapper scope, over this whole element) — see applyPageBg in main.ts. */
 .frame {
-    background: #fff;
+    background: #0f0f1a;
+    background-image: repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.05) 0 8px, transparent 8px 16px);
     overflow: hidden;
 }
 
@@ -618,13 +622,14 @@ html, body {
 /* Mobile view: constrain the iframe so the portal's `window.innerWidth <=
    MOBILE_PORTAL_MAX_WIDTH` check fires and the mobile portal renders. */
 .frame.mobile {
-    background: #0f0f1a;
     display: flex;
     align-items: stretch;
     justify-content: center;
     padding: 16px 0;
 }
 
+/* No stage background: transparent portal pages show the wrapper background
+   through the device screen, same as Desktop mode. */
 .frame.mobile .frame-stage {
     width: 360px;
     max-width: 100%;
@@ -632,7 +637,6 @@ html, body {
     box-shadow: 0 0 0 1px #2b344d, 0 12px 40px rgba(0, 0, 0, 0.5);
     border-radius: 16px;
     overflow: hidden;
-    background: #fff;
 }
 
 /* Mobile view with a device preset: exact device viewport, centered, scroll
@@ -652,7 +656,6 @@ html, body {
 /* Responsive view: exact user-set dimensions via CSS variables, centered in
    the frame with scroll overflow when the stage is larger than the viewport. */
 .frame.responsive {
-    background: #0f0f1a;
     display: flex;
     align-items: safe center;
     justify-content: safe center;
@@ -667,7 +670,6 @@ html, body {
     box-shadow: 0 0 0 1px #2b344d, 0 12px 40px rgba(0, 0, 0, 0.5);
     border-radius: 8px;
     overflow: hidden;
-    background: #fff;
 }
 
 /* Collapsible drawers nested inside a fieldset (e.g. the Wallet group's
@@ -755,6 +757,14 @@ html, body {
     cursor: ew-resize;
 }
 
+.handle-w {
+    top: 0;
+    left: 0;
+    width: 8px;
+    height: 100%;
+    cursor: ew-resize;
+}
+
 .handle-s {
     bottom: 0;
     left: 0;
@@ -769,6 +779,14 @@ html, body {
     width: 18px;
     height: 18px;
     cursor: nwse-resize;
+}
+
+.handle-sw {
+    left: 0;
+    bottom: 0;
+    width: 18px;
+    height: 18px;
+    cursor: nesw-resize;
 }
 
 .resize-handle:hover,


### PR DESCRIPTION
Ticket: https://github.com/Bring-Web3-LTD/TODO/issues/530
_____
Rework the wrapper background into a portal backdrop -  a flat color or an image (partner-site screenshot) shown under the portal iframe, visible wherever the portal page is transparent. The surround around the stage keeps a fixed grey hatch; a scope button extends the backdrop from the stage to the full wrapper.

- Load the image via file picker, clipboard paste (image data or copied URL), or typed URL; toggle it off/on without losing it
- Persist everything across reloads: image in IndexedDB (too large for localStorage), colour/scope/off-on state in localStorage
- Keep backdrop controls active in all view modes (previously disabled in Desktop) and make the stage transparent in Mobile/Responsive so the backdrop shows through there too
- Add west-edge and SW-corner drag-resize handles to the responsive stage (mirrors of the east/SE math against the centered stage)